### PR TITLE
Update `Sprites.Filesystem.build_url` to return sprite specific paths…

### DIFF
--- a/lib/sprites/filesystem.ex
+++ b/lib/sprites/filesystem.ex
@@ -577,9 +577,8 @@ defmodule Sprites.Filesystem do
   # Private Helpers
   # ============================================================================
 
-  defp build_url(_fs, endpoint, params) do
-    query = URI.encode_query(params)
-    "#{endpoint}?#{query}"
+  defp build_url(fs, endpoint, params) do
+    Sprites.Sprite.path(fs.sprite, endpoint, params)
   end
 
   defp resolve_path(_fs, "/" <> _ = absolute_path), do: absolute_path

--- a/lib/sprites/sprite.ex
+++ b/lib/sprites/sprite.ex
@@ -60,6 +60,15 @@ defmodule Sprites.Sprite do
     client.token
   end
 
+  @doc """
+  Builds a path for sprite-specific API endpoints.
+  """
+  @spec path(t(), String.t(), keyword()) :: String.t()
+  def path(%__MODULE__{name: name}, endpoint, params \\ []) do
+    query = if params == [], do: "", else: "?#{URI.encode_query(params)}"
+    "/v1/sprites/#{URI.encode(name)}#{endpoint}#{query}"
+  end
+
   defp build_query_params(command, args, opts) do
     [{"path", command} | Enum.map([command | args], &{"cmd", &1})]
     |> add_stdin_param(opts)

--- a/test/sprites/sprite_test.exs
+++ b/test/sprites/sprite_test.exs
@@ -1,0 +1,37 @@
+defmodule Sprites.SpriteTest do
+  use ExUnit.Case, async: true
+
+  alias Sprites.Sprite
+
+  describe "path/3" do
+    test "it builds the correct path when no param are provided" do
+      client = Sprites.Client.new("test_token", base_url: "https://api.sprites.dev")
+      sprite = Sprite.new(client, "my_sprite")
+
+      url =
+        Sprite.path(sprite, "/fs/list")
+
+      assert url == "/v1/sprites/my_sprite/fs/list"
+    end
+
+    test "it builds the correct path when params are provided as a map" do
+      client = Sprites.Client.new("test_token", base_url: "https://api.sprites.dev")
+      sprite = Sprite.new(client, "my_sprite")
+
+      url =
+        Sprite.path(sprite, "/fs/list", %{path: "/home/user", recursive: true})
+
+      assert url == "/v1/sprites/my_sprite/fs/list?path=%2Fhome%2Fuser&recursive=true"
+    end
+
+    test "it builds the correct path when params are provided as a keyword list" do
+      client = Sprites.Client.new("test_token", base_url: "https://api.sprites.dev")
+      sprite = Sprite.new(client, "my_sprite")
+
+      url =
+        Sprite.path(sprite, "/fs/list", path: "/home/user", recursive: true)
+
+      assert url == "/v1/sprites/my_sprite/fs/list?path=%2Fhome%2Fuser&recursive=true"
+    end
+  end
+end


### PR DESCRIPTION
## What's The Problem?

In the Filesystem module:

```elixir
defp build_url(_fs, endpoint, params) do
  query = URI.encode_query(params)
  "#{endpoint}?#{query}"
end
```

Builds URLs like `/fs/write?`... without the sprite name.

The [API docs](https://docs.sprites.dev/api/v001-rc30/filesystem/#write-file) specify:
```
 PUT /v1/sprites/{name}/fs/write
```

## What Was Done?

A `Sprites.Sprite.path/3` function was added so any caller that can access a `%Sprite{}`, can generate properly scoped API paths, like: 

```
/v1/sprites/my-sprite-name/fs/write
```

**Before:**

```elixir
iex(4)> entries = Sprites.Filesystem.ls!(fs, "/home/sprite")
** (Sprites.Error.FilesystemError) File or directory not found: /home/sprite
    (sprites 0.1.0) lib/sprites/filesystem.ex:199: Sprites.Filesystem.ls!/2
```

**After:**

```elixir
entries = Sprites.Filesystem.ls!(fs, "/home/sprite")
=> [
  ...
  %{
    "isDir" => false,
    "modTime" => "2026-01-14T00:20:01Z",
    "mode" => "644",
    "name" => ".tcshrc",
    "path" => "/home/sprite/.tcshrc",
    "size" => 383,
    "type" => "file"
  },
  %{
    "isDir" => false,
    "modTime" => "2026-01-14T00:20:01Z",
    "mode" => "644",
    "name" => ".zshrc",
    "path" => "/home/sprite/.zshrc",
    "size" => 1159,
    "type" => "file"
  }
]
```