### PR TITLE
Add structured APIError with upgrade_url field

### DIFF
--- a/lib/sprites/errors.ex
+++ b/lib/sprites/errors.ex
@@ -3,14 +3,182 @@ defmodule Sprites.Error do
   Error types for the Sprites SDK.
   """
 
+  @doc "Error code for sprite creation rate limit"
+  def err_code_creation_rate_limited, do: "sprite_creation_rate_limited"
+
+  @doc "Error code for concurrent sprite limit exceeded"
+  def err_code_concurrent_limit_exceeded, do: "concurrent_sprite_limit_exceeded"
+
   defmodule APIError do
-    @moduledoc "Raised when the API returns an error response."
-    defexception [:status, :message, :body]
+    @moduledoc """
+    Raised when the API returns an error response.
+
+    Provides detailed information about rate limits and other API errors.
+    """
+    defexception [
+      :status,
+      :message,
+      :body,
+      # Structured fields from JSON body
+      :error_code,
+      :limit,
+      :window_seconds,
+      :retry_after_seconds,
+      :current_count,
+      :upgrade_available,
+      :upgrade_url,
+      # Fields from HTTP headers
+      :retry_after_header,
+      :rate_limit_limit,
+      :rate_limit_remaining,
+      :rate_limit_reset
+    ]
+
+    @type t :: %__MODULE__{
+            status: integer() | nil,
+            message: String.t() | nil,
+            body: String.t() | nil,
+            error_code: String.t() | nil,
+            limit: integer() | nil,
+            window_seconds: integer() | nil,
+            retry_after_seconds: integer() | nil,
+            current_count: integer() | nil,
+            upgrade_available: boolean() | nil,
+            upgrade_url: String.t() | nil,
+            retry_after_header: integer() | nil,
+            rate_limit_limit: integer() | nil,
+            rate_limit_remaining: integer() | nil,
+            rate_limit_reset: integer() | nil
+          }
 
     @impl true
-    def message(%{status: status, message: msg}) do
+    def message(%{status: status, message: msg}) when is_binary(msg) and msg != "" do
       "API error (#{status}): #{msg}"
     end
+
+    def message(%{status: status, error_code: code}) when is_binary(code) and code != "" do
+      "API error (#{status}): #{code}"
+    end
+
+    def message(%{status: status}) do
+      "API error (#{status})"
+    end
+
+    @doc "Returns true if this is a 429 rate limit error"
+    @spec is_rate_limit_error?(t()) :: boolean()
+    def is_rate_limit_error?(%__MODULE__{status: 429}), do: true
+    def is_rate_limit_error?(%__MODULE__{}), do: false
+
+    @doc "Returns true if this is a sprite creation rate limit error"
+    @spec is_creation_rate_limited?(t()) :: boolean()
+    def is_creation_rate_limited?(%__MODULE__{error_code: code}) do
+      code == Sprites.Error.err_code_creation_rate_limited()
+    end
+
+    @doc "Returns true if this is a concurrent sprite limit error"
+    @spec is_concurrent_limit_exceeded?(t()) :: boolean()
+    def is_concurrent_limit_exceeded?(%__MODULE__{error_code: code}) do
+      code == Sprites.Error.err_code_concurrent_limit_exceeded()
+    end
+
+    @doc """
+    Returns the number of seconds to wait before retrying.
+    Prefers the JSON field, falling back to the header value.
+    """
+    @spec get_retry_after_seconds(t()) :: integer() | nil
+    def get_retry_after_seconds(%__MODULE__{retry_after_seconds: seconds})
+        when is_integer(seconds) and seconds > 0 do
+      seconds
+    end
+
+    def get_retry_after_seconds(%__MODULE__{retry_after_header: seconds})
+        when is_integer(seconds) do
+      seconds
+    end
+
+    def get_retry_after_seconds(%__MODULE__{}), do: nil
+  end
+
+  @doc """
+  Parse a structured API error from an HTTP response.
+
+  Returns `{:ok, %APIError{}}` if status >= 400, `{:ok, nil}` otherwise.
+  """
+  @spec parse_api_error(integer(), binary(), list()) :: {:ok, APIError.t() | nil}
+  def parse_api_error(status, body, headers \\ [])
+
+  def parse_api_error(status, _body, _headers) when status < 400 do
+    {:ok, nil}
+  end
+
+  def parse_api_error(status, body, headers) when status >= 400 do
+    headers_map =
+      headers
+      |> Enum.map(fn {k, v} -> {String.downcase(to_string(k)), to_string(v)} end)
+      |> Map.new()
+
+    # Parse rate limit headers
+    retry_after_header = parse_int_header(headers_map, "retry-after")
+    rate_limit_limit = parse_int_header(headers_map, "x-ratelimit-limit")
+    rate_limit_remaining = parse_int_header(headers_map, "x-ratelimit-remaining")
+    rate_limit_reset = parse_int_header(headers_map, "x-ratelimit-reset")
+
+    # Try to parse JSON body
+    {error_code, message, limit, window_seconds, retry_after_seconds, current_count,
+     upgrade_available,
+     upgrade_url} =
+      case Jason.decode(body) do
+        {:ok, data} when is_map(data) ->
+          {
+            Map.get(data, "error"),
+            Map.get(data, "message"),
+            Map.get(data, "limit"),
+            Map.get(data, "window_seconds"),
+            Map.get(data, "retry_after_seconds"),
+            Map.get(data, "current_count"),
+            Map.get(data, "upgrade_available", false),
+            Map.get(data, "upgrade_url")
+          }
+
+        _ ->
+          # Use raw body as message
+          {nil, body, nil, nil, nil, nil, false, nil}
+      end
+
+    # Fallback message if nothing was parsed
+    final_message =
+      cond do
+        is_binary(message) and message != "" -> message
+        is_binary(error_code) and error_code != "" -> error_code
+        true -> "API error (status #{status})"
+      end
+
+    {:ok,
+     %APIError{
+       status: status,
+       message: final_message,
+       body: body,
+       error_code: error_code,
+       limit: limit,
+       window_seconds: window_seconds,
+       retry_after_seconds: retry_after_seconds,
+       current_count: current_count,
+       upgrade_available: upgrade_available,
+       upgrade_url: upgrade_url,
+       retry_after_header: retry_after_header,
+       rate_limit_limit: rate_limit_limit,
+       rate_limit_remaining: rate_limit_remaining,
+       rate_limit_reset: rate_limit_reset
+     }}
+  end
+
+  defp parse_int_header(headers, key) do
+    case Map.get(headers, key) do
+      nil -> nil
+      value -> String.to_integer(value)
+    end
+  rescue
+    _ -> nil
   end
 
   defmodule CommandError do

--- a/test/errors_test.exs
+++ b/test/errors_test.exs
@@ -1,0 +1,256 @@
+defmodule Sprites.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Sprites.Error
+  alias Sprites.Error.APIError
+
+  describe "APIError" do
+    test "creates basic error" do
+      err = %APIError{status: 500, message: "Something went wrong"}
+      assert Exception.message(err) == "API error (500): Something went wrong"
+    end
+
+    test "creates error with all fields" do
+      err = %APIError{
+        status: 429,
+        message: "Rate limit exceeded",
+        body: ~s({"error": "rate_limited"}),
+        error_code: "sprite_creation_rate_limited",
+        limit: 10,
+        window_seconds: 60,
+        retry_after_seconds: 30,
+        current_count: 5,
+        upgrade_available: true,
+        upgrade_url: "https://fly.io/upgrade",
+        retry_after_header: 25,
+        rate_limit_limit: 100,
+        rate_limit_remaining: 0,
+        rate_limit_reset: 1_706_400_000
+      }
+
+      assert err.status == 429
+      assert err.error_code == "sprite_creation_rate_limited"
+      assert err.limit == 10
+      assert err.window_seconds == 60
+      assert err.retry_after_seconds == 30
+      assert err.current_count == 5
+      assert err.upgrade_available == true
+      assert err.upgrade_url == "https://fly.io/upgrade"
+      assert err.retry_after_header == 25
+      assert err.rate_limit_limit == 100
+      assert err.rate_limit_remaining == 0
+      assert err.rate_limit_reset == 1_706_400_000
+    end
+
+    test "message falls back to error_code when message is empty" do
+      err = %APIError{status: 429, message: "", error_code: "rate_limited"}
+      assert Exception.message(err) == "API error (429): rate_limited"
+    end
+
+    test "message falls back to status only when both are empty" do
+      err = %APIError{status: 500, message: "", error_code: ""}
+      assert Exception.message(err) == "API error (500)"
+    end
+  end
+
+  describe "APIError.is_rate_limit_error?/1" do
+    test "returns true for 429 status" do
+      err = %APIError{status: 429, message: "Rate limited"}
+      assert APIError.is_rate_limit_error?(err) == true
+    end
+
+    test "returns false for non-429 status" do
+      err = %APIError{status: 500, message: "Server error"}
+      assert APIError.is_rate_limit_error?(err) == false
+    end
+  end
+
+  describe "APIError.is_creation_rate_limited?/1" do
+    test "returns true for creation rate limited error code" do
+      err = %APIError{
+        status: 429,
+        message: "Rate limited",
+        error_code: Error.err_code_creation_rate_limited()
+      }
+
+      assert APIError.is_creation_rate_limited?(err) == true
+    end
+
+    test "returns false for other error codes" do
+      err = %APIError{
+        status: 429,
+        message: "Limit exceeded",
+        error_code: Error.err_code_concurrent_limit_exceeded()
+      }
+
+      assert APIError.is_creation_rate_limited?(err) == false
+    end
+  end
+
+  describe "APIError.is_concurrent_limit_exceeded?/1" do
+    test "returns true for concurrent limit error code" do
+      err = %APIError{
+        status: 429,
+        message: "Limit exceeded",
+        error_code: Error.err_code_concurrent_limit_exceeded()
+      }
+
+      assert APIError.is_concurrent_limit_exceeded?(err) == true
+    end
+
+    test "returns false for other error codes" do
+      err = %APIError{
+        status: 429,
+        message: "Rate limited",
+        error_code: Error.err_code_creation_rate_limited()
+      }
+
+      assert APIError.is_concurrent_limit_exceeded?(err) == false
+    end
+  end
+
+  describe "APIError.get_retry_after_seconds/1" do
+    test "prefers JSON retry_after_seconds over header" do
+      err = %APIError{
+        status: 429,
+        message: "Rate limited",
+        retry_after_seconds: 30,
+        retry_after_header: 60
+      }
+
+      assert APIError.get_retry_after_seconds(err) == 30
+    end
+
+    test "falls back to header when JSON field is not set" do
+      err = %APIError{
+        status: 429,
+        message: "Rate limited",
+        retry_after_header: 60
+      }
+
+      assert APIError.get_retry_after_seconds(err) == 60
+    end
+
+    test "returns nil when neither is set" do
+      err = %APIError{status: 429, message: "Rate limited"}
+      assert APIError.get_retry_after_seconds(err) == nil
+    end
+  end
+
+  describe "Error.parse_api_error/3" do
+    test "returns nil for success status codes" do
+      assert {:ok, nil} = Error.parse_api_error(200, "OK")
+      assert {:ok, nil} = Error.parse_api_error(201, "Created")
+      assert {:ok, nil} = Error.parse_api_error(204, "")
+      assert {:ok, nil} = Error.parse_api_error(301, "Moved")
+      assert {:ok, nil} = Error.parse_api_error(399, "Something")
+    end
+
+    test "parses JSON error body" do
+      body =
+        Jason.encode!(%{
+          "error" => "sprite_creation_rate_limited",
+          "message" => "Rate limit exceeded",
+          "limit" => 10,
+          "window_seconds" => 60,
+          "retry_after_seconds" => 30,
+          "upgrade_available" => true,
+          "upgrade_url" => "https://fly.io/upgrade"
+        })
+
+      assert {:ok, err} = Error.parse_api_error(429, body)
+      assert err.status == 429
+      assert err.error_code == "sprite_creation_rate_limited"
+      assert err.message == "Rate limit exceeded"
+      assert err.limit == 10
+      assert err.window_seconds == 60
+      assert err.retry_after_seconds == 30
+      assert err.upgrade_available == true
+      assert err.upgrade_url == "https://fly.io/upgrade"
+    end
+
+    test "parses rate limit headers" do
+      headers = [
+        {"Retry-After", "30"},
+        {"X-RateLimit-Limit", "100"},
+        {"X-RateLimit-Remaining", "0"},
+        {"X-RateLimit-Reset", "1706400000"}
+      ]
+
+      body = ~s({"error": "rate_limited", "message": "Too many requests"})
+
+      assert {:ok, err} = Error.parse_api_error(429, body, headers)
+      assert err.retry_after_header == 30
+      assert err.rate_limit_limit == 100
+      assert err.rate_limit_remaining == 0
+      assert err.rate_limit_reset == 1_706_400_000
+    end
+
+    test "parses lowercase headers" do
+      headers = [
+        {"retry-after", "30"},
+        {"x-ratelimit-limit", "100"}
+      ]
+
+      body = ~s({"message": "Rate limited"})
+
+      assert {:ok, err} = Error.parse_api_error(429, body, headers)
+      assert err.retry_after_header == 30
+      assert err.rate_limit_limit == 100
+    end
+
+    test "handles non-JSON body" do
+      body = "Internal Server Error: something went wrong"
+
+      assert {:ok, err} = Error.parse_api_error(500, body)
+      assert err.status == 500
+      assert err.message == body
+      assert err.error_code == nil
+    end
+
+    test "handles empty body" do
+      assert {:ok, err} = Error.parse_api_error(500, "")
+      assert err.status == 500
+      assert err.message =~ "API error"
+    end
+
+    test "handles invalid header values gracefully" do
+      headers = [
+        {"Retry-After", "not-a-number"},
+        {"X-RateLimit-Limit", "invalid"}
+      ]
+
+      body = ~s({"message": "Error"})
+
+      assert {:ok, err} = Error.parse_api_error(429, body, headers)
+      assert err.retry_after_header == nil
+      assert err.rate_limit_limit == nil
+    end
+
+    test "parses concurrent limit error" do
+      body =
+        Jason.encode!(%{
+          "error" => "concurrent_sprite_limit_exceeded",
+          "message" => "Too many concurrent sprites",
+          "current_count" => 5,
+          "limit" => 5
+        })
+
+      assert {:ok, err} = Error.parse_api_error(429, body)
+      assert err.error_code == Error.err_code_concurrent_limit_exceeded()
+      assert err.current_count == 5
+      assert err.limit == 5
+      assert APIError.is_concurrent_limit_exceeded?(err) == true
+    end
+  end
+
+  describe "error code constants" do
+    test "creation rate limited code" do
+      assert Error.err_code_creation_rate_limited() == "sprite_creation_rate_limited"
+    end
+
+    test "concurrent limit exceeded code" do
+      assert Error.err_code_concurrent_limit_exceeded() == "concurrent_sprite_limit_exceeded"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `upgrade_url` and other structured fields to `APIError` struct
- Add `parse_api_error/3` function for parsing HTTP error responses
- Add helper functions: `is_rate_limit_error?/1`, `is_creation_rate_limited?/1`, `is_concurrent_limit_exceeded?/1`, `get_retry_after_seconds/1`
- Update `command.ex` to parse HTTP errors as structured `APIError` on websocket dial failures
- Add comprehensive tests for `APIError` and `parse_api_error`

This matches the error handling improvements in the Go SDK, allowing callers to access structured error information (error code, limits, upgrade URL) directly from rate limit and other API errors.