### PR TITLE
Add control mode with fallback for Elixir SDK

### DIFF
--- a/lib/sprites.ex
+++ b/lib/sprites.ex
@@ -42,11 +42,13 @@ defmodule Sprites do
 
     * `:base_url` - API base URL (default: "https://api.sprites.dev")
     * `:timeout` - HTTP timeout in milliseconds (default: 30_000)
+    * `:control_mode` - Enable control mode for multiplexed exec over a single WebSocket per sprite (default: false)
 
   ## Examples
 
       client = Sprites.new("my-token")
       client = Sprites.new("my-token", base_url: "https://custom.api.dev")
+      client = Sprites.new("my-token", control_mode: true)
   """
   @spec new(String.t(), keyword()) :: client()
   def new(token, opts \\ []) do

--- a/lib/sprites/client.ex
+++ b/lib/sprites/client.ex
@@ -7,13 +7,14 @@ defmodule Sprites.Client do
   @default_timeout 30_000
   @create_timeout 120_000
 
-  defstruct [:token, :base_url, :timeout, :req]
+  defstruct [:token, :base_url, :timeout, :req, control_mode: false]
 
   @type t :: %__MODULE__{
           token: String.t(),
           base_url: String.t(),
           timeout: non_neg_integer(),
-          req: Req.Request.t()
+          req: Req.Request.t(),
+          control_mode: boolean()
         }
 
   @doc """
@@ -23,11 +24,13 @@ defmodule Sprites.Client do
 
     * `:base_url` - API base URL (default: "https://api.sprites.dev")
     * `:timeout` - HTTP timeout in milliseconds (default: 30_000)
+    * `:control_mode` - Enable control mode for multiplexed exec over a single WebSocket (default: false)
   """
   @spec new(String.t(), keyword()) :: t()
   def new(token, opts \\ []) do
     base_url = Keyword.get(opts, :base_url, @default_base_url) |> normalize_url()
     timeout = Keyword.get(opts, :timeout, @default_timeout)
+    control_mode = Keyword.get(opts, :control_mode, false)
 
     req =
       Req.new(
@@ -40,7 +43,8 @@ defmodule Sprites.Client do
       token: token,
       base_url: base_url,
       timeout: timeout,
-      req: req
+      req: req,
+      control_mode: control_mode
     }
   end
 

--- a/lib/sprites/control.ex
+++ b/lib/sprites/control.ex
@@ -1,0 +1,182 @@
+defmodule Sprites.Control do
+  @moduledoc """
+  Module-level pool management for control connections.
+
+  Uses ETS tables to store per-sprite pools and control support flags.
+  Pools are created lazily on first checkout and cached for reuse.
+  """
+
+  alias Sprites.{ControlPool, Sprite}
+
+  @pools_table :sprites_control_pools
+  @support_table :sprites_control_support
+
+  @doc """
+  Ensures ETS tables exist. Safe to call multiple times.
+  """
+  @spec ensure_tables() :: :ok
+  def ensure_tables do
+    if :ets.whereis(@pools_table) == :undefined or
+         :ets.whereis(@support_table) == :undefined do
+      # Tables must be owned by a long-lived process so they survive
+      # across short-lived Command GenServers.
+      ensure_table_owner()
+    end
+
+    :ok
+  end
+
+  defp ensure_table_owner do
+    name = :sprites_control_table_owner
+
+    case Process.whereis(name) do
+      nil ->
+        caller = self()
+
+        pid =
+          spawn(fn ->
+            if :ets.whereis(@pools_table) == :undefined do
+              :ets.new(@pools_table, [:named_table, :public, :set])
+            end
+
+            if :ets.whereis(@support_table) == :undefined do
+              :ets.new(@support_table, [:named_table, :public, :set])
+            end
+
+            send(caller, {:tables_ready, self()})
+
+            # Stay alive forever — tables die when their owner dies
+            ref = make_ref()
+
+            receive do
+              ^ref -> :ok
+            end
+          end)
+
+        try do
+          Process.register(pid, name)
+        rescue
+          ArgumentError ->
+            Process.exit(pid, :normal)
+        end
+
+        receive do
+          {:tables_ready, ^pid} -> :ok
+        after
+          5_000 -> :ok
+        end
+
+      _pid ->
+        :ok
+    end
+  end
+
+  @doc """
+  Checks out a control connection for the given sprite.
+
+  Creates a pool if one doesn't exist yet.
+  """
+  @spec checkout(Sprite.t()) :: {:ok, pid()} | {:error, term()}
+  def checkout(%Sprite{} = sprite) do
+    ensure_tables()
+    pool = get_or_create_pool(sprite)
+    ControlPool.checkout(pool)
+  end
+
+  @doc """
+  Returns a control connection to the pool for the given sprite.
+  """
+  @spec checkin(Sprite.t(), pid()) :: :ok
+  def checkin(%Sprite{} = sprite, conn_pid) do
+    ensure_tables()
+    key = sprite_key(sprite)
+
+    case :ets.lookup(@pools_table, key) do
+      [{^key, pool}] ->
+        ControlPool.checkin(pool, conn_pid)
+
+      [] ->
+        :ok
+    end
+  end
+
+  @doc """
+  Returns whether control mode is believed to be supported for the given sprite.
+
+  Returns `true` by default (until `mark_unsupported/1` is called).
+  """
+  @spec control_supported?(Sprite.t()) :: boolean()
+  def control_supported?(%Sprite{} = sprite) do
+    ensure_tables()
+    key = sprite_key(sprite)
+
+    case :ets.lookup(@support_table, key) do
+      [{^key, false}] -> false
+      _ -> true
+    end
+  end
+
+  @doc """
+  Marks a sprite as not supporting control mode.
+
+  Prevents future checkout attempts from trying the control endpoint.
+  """
+  @spec mark_unsupported(Sprite.t()) :: :ok
+  def mark_unsupported(%Sprite{} = sprite) do
+    ensure_tables()
+    key = sprite_key(sprite)
+    :ets.insert(@support_table, {key, false})
+    :ok
+  end
+
+  @doc """
+  Closes all control connections for the given sprite and removes the pool.
+  """
+  @spec close(Sprite.t()) :: :ok
+  def close(%Sprite{} = sprite) do
+    ensure_tables()
+    key = sprite_key(sprite)
+
+    case :ets.lookup(@pools_table, key) do
+      [{^key, pool}] ->
+        ControlPool.close(pool)
+        :ets.delete(@pools_table, key)
+
+      [] ->
+        :ok
+    end
+
+    :ok
+  end
+
+  # Private helpers
+
+  defp get_or_create_pool(sprite) do
+    key = sprite_key(sprite)
+
+    case :ets.lookup(@pools_table, key) do
+      [{^key, pool}] ->
+        if Process.alive?(pool) do
+          pool
+        else
+          create_pool(sprite, key)
+        end
+
+      [] ->
+        create_pool(sprite, key)
+    end
+  end
+
+  defp create_pool(sprite, key) do
+    url = Sprite.control_url(sprite)
+    token = Sprite.token(sprite)
+
+    {:ok, pool} = ControlPool.start(url: url, token: token)
+    :ets.insert(@pools_table, {key, pool})
+    pool
+  end
+
+  defp sprite_key(%Sprite{name: name, client: client}) do
+    {client.base_url, name}
+  end
+end

--- a/lib/sprites/control_conn.ex
+++ b/lib/sprites/control_conn.ex
@@ -1,0 +1,336 @@
+defmodule Sprites.ControlConn do
+  @moduledoc """
+  A persistent WebSocket connection to a sprite's control endpoint.
+
+  Multiplexes exec operations over a single connection at `/v1/sprites/{name}/control`.
+  Each connection handles one operation at a time — the pool manages concurrency.
+
+  Messages sent to the owner process during an active operation:
+
+    * `{:control_data, :binary, data}` — binary frame (stdout/stderr/exit in protocol encoding)
+    * `{:control_data, :text, text}` — text frame (JSON messages like port, resize)
+    * `{:control_op_complete, exit_code}` — operation completed
+    * `{:control_op_error, message}` — operation errored
+  """
+
+  use GenServer
+  require Logger
+
+  @control_prefix "control:"
+
+  # Client API
+
+  @doc """
+  Starts a control connection to the given sprite.
+
+  Returns `{:error, {:control_not_supported, status}}` if the server returns 404.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc """
+  Starts a control connection (unlinked) to the given sprite.
+
+  Returns `{:error, {:control_not_supported, status}}` if the server returns 404.
+  """
+  @spec start(keyword()) :: GenServer.on_start()
+  def start(opts) do
+    GenServer.start(__MODULE__, opts)
+  end
+
+  @doc """
+  Starts an operation on this control connection.
+
+  Sends an `op.start` control message. The owner process will receive
+  data frames and completion messages.
+  """
+  @spec start_op(pid(), pid(), String.t(), map()) :: :ok | {:error, term()}
+  def start_op(pid, owner, op, args) do
+    GenServer.call(pid, {:start_op, owner, op, args})
+  end
+
+  @doc """
+  Sends binary data (stdin) through the control connection.
+  """
+  @spec send_data(pid(), binary()) :: :ok
+  def send_data(pid, data) do
+    GenServer.cast(pid, {:send_data, data})
+  end
+
+  @doc """
+  Sends a text frame through the control connection.
+  """
+  @spec send_text(pid(), String.t()) :: :ok
+  def send_text(pid, text) do
+    GenServer.cast(pid, {:send_text, text})
+  end
+
+  @doc """
+  Releases the connection, clearing the current owner.
+  """
+  @spec release(pid()) :: :ok
+  def release(pid) do
+    GenServer.cast(pid, :release)
+  end
+
+  @doc """
+  Closes the control connection.
+  """
+  @spec close(pid()) :: :ok
+  def close(pid) do
+    GenServer.cast(pid, :close)
+  end
+
+  # GenServer callbacks
+
+  @impl true
+  def init(opts) do
+    url = Keyword.fetch!(opts, :url)
+    token = Keyword.fetch!(opts, :token)
+
+    case do_connect(url, token) do
+      {:ok, conn, stream_ref} ->
+        {:ok,
+         %{
+           conn: conn,
+           stream_ref: stream_ref,
+           owner: nil,
+           op_active: false
+         }}
+
+      {:error, {:upgrade_failed, 404}} ->
+        {:stop, {:control_not_supported, 404}}
+
+      {:error, %Sprites.Error.APIError{status: 404}} ->
+        {:stop, {:control_not_supported, 404}}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_call({:start_op, owner, op, args}, _from, state) do
+    if state.op_active do
+      {:reply, {:error, :operation_in_progress}, state}
+    else
+      msg =
+        Jason.encode!(%{
+          type: "op.start",
+          op: op,
+          args: args
+        })
+
+      frame = @control_prefix <> msg
+      :gun.ws_send(state.conn, state.stream_ref, {:text, frame})
+      {:reply, :ok, %{state | owner: owner, op_active: true}}
+    end
+  end
+
+  @impl true
+  def handle_cast({:send_data, data}, %{conn: conn, stream_ref: stream_ref} = state) do
+    :gun.ws_send(conn, stream_ref, {:binary, data})
+    {:noreply, state}
+  end
+
+  def handle_cast({:send_text, text}, %{conn: conn, stream_ref: stream_ref} = state) do
+    :gun.ws_send(conn, stream_ref, {:text, text})
+    {:noreply, state}
+  end
+
+  def handle_cast(:release, state) do
+    {:noreply, %{state | owner: nil, op_active: false}}
+  end
+
+  def handle_cast(:close, %{conn: conn} = state) do
+    :gun.close(conn)
+    {:stop, :normal, %{state | conn: nil}}
+  end
+
+  @impl true
+  def handle_info({:gun_ws, conn, _stream_ref, {:binary, data}}, %{conn: conn} = state) do
+    if state.owner do
+      send(state.owner, {:control_data, :binary, data})
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info({:gun_ws, conn, _stream_ref, {:text, text}}, %{conn: conn} = state) do
+    if String.starts_with?(text, @control_prefix) do
+      payload = String.slice(text, byte_size(@control_prefix), byte_size(text))
+      handle_control_message(payload, state)
+    else
+      if state.owner do
+        send(state.owner, {:control_data, :text, text})
+      end
+
+      {:noreply, state}
+    end
+  end
+
+  def handle_info({:gun_ws, conn, _stream_ref, {:close, _code, _reason}}, %{conn: conn} = state) do
+    if state.owner && state.op_active do
+      send(state.owner, {:control_op_error, "connection closed"})
+    end
+
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:gun_down, conn, _protocol, _reason, _killed}, %{conn: conn} = state) do
+    if state.owner && state.op_active do
+      send(state.owner, {:control_op_error, "connection down"})
+    end
+
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:gun_error, conn, _stream_ref, reason}, %{conn: conn} = state) do
+    if state.owner && state.op_active do
+      send(state.owner, {:control_op_error, "gun error: #{inspect(reason)}"})
+    end
+
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:gun_error, conn, reason}, %{conn: conn} = state) do
+    if state.owner && state.op_active do
+      send(state.owner, {:control_op_error, "gun error: #{inspect(reason)}"})
+    end
+
+    {:stop, :normal, state}
+  end
+
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def terminate(_reason, %{conn: conn}) when conn != nil do
+    :gun.close(conn)
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  # Private helpers
+
+  defp handle_control_message(payload, state) do
+    case Jason.decode(payload) do
+      {:ok, %{"type" => "op.complete", "args" => %{"exitCode" => exit_code}}} ->
+        if state.owner do
+          send(state.owner, {:control_op_complete, exit_code})
+        end
+
+        {:noreply, %{state | op_active: false}}
+
+      {:ok, %{"type" => "op.complete"}} ->
+        if state.owner do
+          send(state.owner, {:control_op_complete, 0})
+        end
+
+        {:noreply, %{state | op_active: false}}
+
+      {:ok, %{"type" => "op.error", "args" => %{"error" => error}}} ->
+        if state.owner do
+          send(state.owner, {:control_op_error, error})
+        end
+
+        {:noreply, %{state | op_active: false}}
+
+      {:ok, %{"type" => "op.error"}} ->
+        if state.owner do
+          send(state.owner, {:control_op_error, "unknown error"})
+        end
+
+        {:noreply, %{state | op_active: false}}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  defp do_connect(url, token) do
+    uri = URI.parse(url)
+    host = String.to_charlist(uri.host)
+    port = uri.port || if(uri.scheme == "wss", do: 443, else: 80)
+
+    transport = if uri.scheme == "wss", do: :tls, else: :tcp
+
+    gun_opts = %{
+      protocols: [:http],
+      transport: transport,
+      tls_opts: [
+        verify: :verify_peer,
+        cacerts: :public_key.cacerts_get(),
+        depth: 3,
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    }
+
+    case :gun.open(host, port, gun_opts) do
+      {:ok, conn} ->
+        case :gun.await_up(conn, 10_000) do
+          {:ok, _protocol} ->
+            path = "#{uri.path}?#{uri.query || ""}"
+            headers = [{"authorization", "Bearer #{token}"}]
+            stream_ref = :gun.ws_upgrade(conn, path, headers)
+
+            receive do
+              {:gun_upgrade, ^conn, ^stream_ref, ["websocket"], _headers} ->
+                {:ok, conn, stream_ref}
+
+              {:gun_response, ^conn, ^stream_ref, is_fin, status, headers} ->
+                body = read_response_body(conn, stream_ref, is_fin)
+                :gun.close(conn)
+
+                case Sprites.Error.parse_api_error(status, body, headers) do
+                  {:ok, %Sprites.Error.APIError{} = api_error} ->
+                    {:error, api_error}
+
+                  {:ok, nil} ->
+                    {:error, {:upgrade_failed, status}}
+                end
+
+              {:gun_error, ^conn, ^stream_ref, reason} ->
+                :gun.close(conn)
+                {:error, reason}
+
+              {:gun_error, ^conn, reason} ->
+                :gun.close(conn)
+                {:error, reason}
+            after
+              10_000 ->
+                :gun.close(conn)
+                {:error, :upgrade_timeout}
+            end
+
+          {:error, reason} ->
+            :gun.close(conn)
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp read_response_body(_conn, _stream_ref, :fin), do: ""
+
+  defp read_response_body(conn, stream_ref, :nofin) do
+    receive do
+      {:gun_data, ^conn, ^stream_ref, :fin, data} ->
+        data
+
+      {:gun_data, ^conn, ^stream_ref, :nofin, data} ->
+        data <> read_response_body(conn, stream_ref, :nofin)
+    after
+      5_000 ->
+        ""
+    end
+  end
+end

--- a/lib/sprites/control_pool.ex
+++ b/lib/sprites/control_pool.ex
@@ -1,0 +1,175 @@
+defmodule Sprites.ControlPool do
+  @moduledoc """
+  Pool of `Sprites.ControlConn` processes for a single sprite.
+
+  Manages connection lifecycle with checkout/checkin semantics and
+  automatic draining when the pool grows too large.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Sprites.ControlConn
+
+  @max_pool_size 100
+  @drain_threshold 20
+  @drain_target 10
+
+  # Client API
+
+  @doc """
+  Starts a control pool for the given sprite.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc """
+  Starts a control pool (unlinked) for the given sprite.
+  """
+  @spec start(keyword()) :: GenServer.on_start()
+  def start(opts) do
+    GenServer.start(__MODULE__, opts)
+  end
+
+  @doc """
+  Checks out a control connection from the pool.
+
+  Returns an idle connection or creates a new one.
+  Returns `{:error, {:control_not_supported, 404}}` if the server doesn't support control mode.
+  """
+  @spec checkout(pid()) :: {:ok, pid()} | {:error, term()}
+  def checkout(pid) do
+    GenServer.call(pid, :checkout, 30_000)
+  end
+
+  @doc """
+  Returns a connection to the pool.
+  """
+  @spec checkin(pid(), pid()) :: :ok
+  def checkin(pid, conn_pid) do
+    GenServer.cast(pid, {:checkin, conn_pid})
+  end
+
+  @doc """
+  Closes all connections in the pool and stops the GenServer.
+  """
+  @spec close(pid()) :: :ok
+  def close(pid) do
+    GenServer.cast(pid, :close)
+  end
+
+  # GenServer callbacks
+
+  @impl true
+  def init(opts) do
+    {:ok,
+     %{
+       url: Keyword.fetch!(opts, :url),
+       token: Keyword.fetch!(opts, :token),
+       conns: %{}
+     }}
+  end
+
+  @impl true
+  def handle_call(:checkout, _from, state) do
+    # Try to find an idle connection
+    case find_idle(state.conns) do
+      {:ok, conn_pid} ->
+        {_status, ref} = Map.get(state.conns, conn_pid)
+        conns = Map.put(state.conns, conn_pid, {:busy, ref})
+        {:reply, {:ok, conn_pid}, %{state | conns: conns}}
+
+      :none ->
+        if map_size(state.conns) >= @max_pool_size do
+          {:reply, {:error, :pool_full}, state}
+        else
+          case create_conn(state.url, state.token) do
+            {:ok, conn_pid} ->
+              ref = Process.monitor(conn_pid)
+              conns = Map.put(state.conns, conn_pid, {:busy, ref})
+              {:reply, {:ok, conn_pid}, %{state | conns: conns}}
+
+            {:error, reason} ->
+              {:reply, {:error, reason}, state}
+          end
+        end
+    end
+  end
+
+  @impl true
+  def handle_cast({:checkin, conn_pid}, state) do
+    case Map.get(state.conns, conn_pid) do
+      nil ->
+        {:noreply, state}
+
+      {_status, ref} ->
+        ControlConn.release(conn_pid)
+        conns = Map.put(state.conns, conn_pid, {:idle, ref})
+        state = %{state | conns: conns}
+        {:noreply, maybe_drain(state)}
+    end
+  end
+
+  def handle_cast(:close, state) do
+    Enum.each(state.conns, fn {conn_pid, _status} ->
+      ControlConn.close(conn_pid)
+    end)
+
+    {:stop, :normal, %{state | conns: %{}}}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, conn_pid, _reason}, state) do
+    conns = Map.delete(state.conns, conn_pid)
+    {:noreply, %{state | conns: conns}}
+  end
+
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  # Private helpers
+
+  defp find_idle(conns) do
+    case Enum.find(conns, fn {_pid, status} -> match?({:idle, _}, status) end) do
+      {pid, _} -> {:ok, pid}
+      nil -> :none
+    end
+  end
+
+  defp create_conn(url, token) do
+    case ControlConn.start(url: url, token: token) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp maybe_drain(state) do
+    if map_size(state.conns) > @drain_threshold do
+      do_drain(state)
+    else
+      state
+    end
+  end
+
+  defp do_drain(state) do
+    to_close = map_size(state.conns) - @drain_target
+
+    if to_close > 0 do
+      idle_pids =
+        state.conns
+        |> Enum.filter(fn {_pid, status} -> match?({:idle, _}, status) end)
+        |> Enum.map(fn {pid, _} -> pid end)
+        |> Enum.take(to_close)
+
+      Enum.each(idle_pids, &ControlConn.close/1)
+
+      conns = Map.drop(state.conns, idle_pids)
+      %{state | conns: conns}
+    else
+      state
+    end
+  end
+end

--- a/lib/sprites/sprite.ex
+++ b/lib/sprites/sprite.ex
@@ -53,6 +53,26 @@ defmodule Sprites.Sprite do
   end
 
   @doc """
+  Builds the WebSocket URL for the control endpoint.
+  """
+  @spec control_url(t()) :: String.t()
+  def control_url(%__MODULE__{client: client, name: name}) do
+    base =
+      client.base_url
+      |> String.replace(~r/^http/, "ws")
+
+    "#{base}/v1/sprites/#{URI.encode(name)}/control"
+  end
+
+  @doc """
+  Returns whether control mode is enabled for this sprite's client.
+  """
+  @spec control_mode?(t()) :: boolean()
+  def control_mode?(%__MODULE__{client: client}) do
+    client.control_mode
+  end
+
+  @doc """
   Returns the authorization token for this sprite's client.
   """
   @spec token(t()) :: String.t()

--- a/test/control_test.exs
+++ b/test/control_test.exs
@@ -1,0 +1,81 @@
+defmodule Sprites.ControlTest do
+  use ExUnit.Case, async: true
+
+  alias Sprites.{Client, Sprite, Control}
+
+  describe "Client control_mode" do
+    test "defaults to false" do
+      client = Client.new("test-token")
+      assert client.control_mode == false
+    end
+
+    test "can be set to true" do
+      client = Client.new("test-token", control_mode: true)
+      assert client.control_mode == true
+    end
+
+    test "can be explicitly set to false" do
+      client = Client.new("test-token", control_mode: false)
+      assert client.control_mode == false
+    end
+  end
+
+  describe "Sprite.control_mode?/1" do
+    test "reflects client control_mode setting" do
+      client = Client.new("test-token", control_mode: true)
+      sprite = Sprite.new(client, "my-sprite")
+      assert Sprite.control_mode?(sprite) == true
+    end
+
+    test "returns false when client has control_mode disabled" do
+      client = Client.new("test-token")
+      sprite = Sprite.new(client, "my-sprite")
+      assert Sprite.control_mode?(sprite) == false
+    end
+  end
+
+  describe "Sprite.control_url/1" do
+    test "builds correct URL with https base" do
+      client = Client.new("test-token", base_url: "https://api.sprites.dev")
+      sprite = Sprite.new(client, "my-sprite")
+      assert Sprite.control_url(sprite) == "wss://api.sprites.dev/v1/sprites/my-sprite/control"
+    end
+
+    test "builds correct URL with http base" do
+      client = Client.new("test-token", base_url: "http://localhost:8080")
+      sprite = Sprite.new(client, "my-sprite")
+      assert Sprite.control_url(sprite) == "ws://localhost:8080/v1/sprites/my-sprite/control"
+    end
+
+    test "encodes sprite name in URL" do
+      client = Client.new("test-token", base_url: "https://api.sprites.dev")
+      sprite = Sprite.new(client, "my sprite")
+
+      assert Sprite.control_url(sprite) ==
+               "wss://api.sprites.dev/v1/sprites/my%20sprite/control"
+    end
+  end
+
+  describe "Control.control_supported?/1" do
+    test "returns true by default for new sprites" do
+      client = Client.new("test-token")
+      sprite = Sprite.new(client, "supported-sprite-#{System.unique_integer([:positive])}")
+      assert Control.control_supported?(sprite) == true
+    end
+
+    test "returns false after mark_unsupported" do
+      client = Client.new("test-token")
+      sprite = Sprite.new(client, "unsupported-sprite-#{System.unique_integer([:positive])}")
+
+      Control.mark_unsupported(sprite)
+      assert Control.control_supported?(sprite) == false
+    end
+  end
+
+  describe "Sprites.new/2" do
+    test "passes control_mode to client" do
+      client = Sprites.new("test-token", control_mode: true)
+      assert client.control_mode == true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add control mode that multiplexes exec operations over a single persistent WebSocket per sprite (`/v1/sprites/{name}/control`), matching Go/JS/Python SDK implementations
- Opt-in via `control_mode: true` on the client; gracefully falls back to direct per-command WebSocket if the server returns 404
- Per-sprite support flag cached in ETS to avoid repeated 404 attempts; connection pooling with checkout/checkin and auto-drain

## Test plan
- [x] 11 unit tests for control mode (client flags, URL building, support caching)
- [x] E2E test passing for `test123` (control supported — uses multiplexed WebSocket)
- [x] E2E test passing for `test` and `test1234` (control not supported — falls back to direct WebSocket)
- [x] Full `mix test` suite passes (34/34, excluding pre-existing `Sprites.hello` test)