### PR TITLE
Fix attach_session to use path-based URL format

### DIFF
--- a/lib/sprites.ex
+++ b/lib/sprites.ex
@@ -354,8 +354,6 @@ defmodule Sprites do
   @spec attach_session(sprite(), String.t(), keyword()) :: {:ok, command()} | {:error, term()}
   def attach_session(sprite, session_id, opts \\ []) do
     opts = Keyword.put(opts, :session_id, session_id)
-    # When attaching to a session, we spawn with empty command
-    # The session_id will be sent as a query param
     Command.start(sprite, "", [], opts)
   end
 

--- a/lib/sprites/sprite.ex
+++ b/lib/sprites/sprite.ex
@@ -46,10 +46,17 @@ defmodule Sprites.Sprite do
       client.base_url
       |> String.replace(~r/^http/, "ws")
 
-    path = "/v1/sprites/#{URI.encode(name)}/exec"
-    query_params = build_query_params(command, args, opts)
+    case Keyword.get(opts, :session_id) do
+      nil ->
+        path = "/v1/sprites/#{URI.encode(name)}/exec"
+        query_params = build_query_params(command, args, opts)
+        "#{base}#{path}?#{URI.encode_query(query_params)}"
 
-    "#{base}#{path}?#{URI.encode_query(query_params)}"
+      session_id ->
+        path = "/v1/sprites/#{URI.encode(name)}/exec/#{URI.encode(session_id)}"
+        query_params = build_attach_params(opts)
+        "#{base}#{path}?#{URI.encode_query(query_params)}"
+    end
   end
 
   @doc """
@@ -68,6 +75,12 @@ defmodule Sprites.Sprite do
     |> add_tty_params(opts)
     |> add_detachable_param(opts)
     |> add_session_id_param(opts)
+  end
+
+  defp build_attach_params(opts) do
+    []
+    |> add_stdin_param(opts)
+    |> add_tty_params(opts)
   end
 
   defp add_stdin_param(params, opts) do


### PR DESCRIPTION
The server expects the session ID as a path parameter (/v1/sprites/{name}/exec/{session_id}) not a query parameter. This matches the Go SDK behavior and correctly reattaches to existing sessions instead of spawning new ones.