### PR TITLE
Fix attach_session URL to match sprites-go and sprites-py

### DIFF
--- a/lib/sprites/sprite.ex
+++ b/lib/sprites/sprite.ex
@@ -39,6 +39,11 @@ defmodule Sprites.Sprite do
 
   @doc """
   Builds the WebSocket URL for command execution.
+
+  When `opts[:session_id]` is set, builds an attach URL of the form
+  `/v1/sprites/:name/exec/:session_id` (matching the sprites-go and
+  sprites-py SDKs). Without `:session_id`, builds the spawn URL with
+  command/args as query params.
   """
   @spec exec_url(t(), String.t(), [String.t()], keyword()) :: String.t()
   def exec_url(%__MODULE__{client: client, name: name}, command, args, opts) do
@@ -46,7 +51,12 @@ defmodule Sprites.Sprite do
       client.base_url
       |> String.replace(~r/^http/, "ws")
 
-    path = "/v1/sprites/#{URI.encode(name)}/exec"
+    path =
+      case Keyword.get(opts, :session_id) do
+        nil -> "/v1/sprites/#{URI.encode(name)}/exec"
+        sid -> "/v1/sprites/#{URI.encode(name)}/exec/#{URI.encode(sid)}"
+      end
+
     query_params = build_query_params(command, args, opts)
 
     "#{base}#{path}?#{URI.encode_query(query_params)}"
@@ -61,13 +71,23 @@ defmodule Sprites.Sprite do
   end
 
   defp build_query_params(command, args, opts) do
-    [{"path", command} | Enum.map([command | args], &{"cmd", &1})]
-    |> add_stdin_param(opts)
-    |> add_dir_param(opts)
-    |> add_env_params(opts)
-    |> add_tty_params(opts)
-    |> add_detachable_param(opts)
-    |> add_session_id_param(opts)
+    # When attaching to an existing session (`:session_id` set), the server
+    # ignores cmd/path/env/dir/detachable — they belong to the original spawn.
+    # Only stdin/tty are meaningful for the attach side.
+    case Keyword.get(opts, :session_id) do
+      nil ->
+        [{"path", command} | Enum.map([command | args], &{"cmd", &1})]
+        |> add_stdin_param(opts)
+        |> add_dir_param(opts)
+        |> add_env_params(opts)
+        |> add_tty_params(opts)
+        |> add_detachable_param(opts)
+
+      _session_id ->
+        []
+        |> add_stdin_param(opts)
+        |> add_tty_params(opts)
+    end
   end
 
   defp add_stdin_param(params, opts) do
@@ -107,10 +127,4 @@ defmodule Sprites.Sprite do
     end
   end
 
-  defp add_session_id_param(params, opts) do
-    case Keyword.get(opts, :session_id) do
-      nil -> params
-      session_id -> [{"session_id", session_id} | params]
-    end
-  end
 end


### PR DESCRIPTION
## Summary

`Sprites.attach_session/3` was building URLs as `/v1/sprites/:name/exec?session_id=X`, but the server expects the **path-based** form `/v1/sprites/:name/exec/:session_id` — the same shape both `sprites-go` and `sprites-py` use.

## Symptom

`attach_session` would return `{:ok, command}` because the WebSocket upgrade succeeded — the server saw the bad URL as a fresh exec with empty command. The originally detached process kept running on the sprite, but no output ever flowed to the new connection. End result: it was impossible to recover an in-flight `detachable: true` command after a client-side crash.

## Fix

When `:session_id` is set in opts:

- Build the attach URL with the session id in the **path**, matching the other SDKs.
- Skip spawn-only query params (`path`/`cmd`/`env`/`dir`/`detachable`) — the server ignores them on attach since they belong to the original spawn.
- `stdin`/`tty` are still forwarded since they're meaningful for the attached side.

## Test plan

- [x] Existing test suite still passes (24 tests, 1 unrelated boilerplate failure).
- [x] Verified end-to-end with a probe:
  1. Spawn `bash -c "echo BEFORE; sleep 20; echo AFTER"` with `detachable: true`.
  2. Hard-kill the `Command` GenServer mid-sleep.
  3. `list_sessions` shows the detached session with `is_active: false`.
  4. `attach_session` to that id.
  5. Observed: `BEFORE` replayed from the session buffer, `AFTER` streamed live post-disconnect, clean `exit 0` reported.
- [ ] Reviewer to confirm against the server-side URL routing in sprites.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)