### PR TITLE
Decode command exit frames correctly

### DIFF
--- a/lib/sprites/command.ex
+++ b/lib/sprites/command.ex
@@ -521,7 +521,7 @@ defmodule Sprites.Command do
         send(owner, {:port, %{ref: ref}, port})
         {:noreply, state}
 
-      {:ok, %{"type" => "exit", "code" => code}} ->
+      {:ok, %{"type" => "exit", "exit_code" => code}} ->
         if state.using_control do
           send(owner, {:exit, %{ref: ref}, code})
           {:noreply, %{state | exit_code: code}}

--- a/lib/sprites/command.ex
+++ b/lib/sprites/command.ex
@@ -521,7 +521,9 @@ defmodule Sprites.Command do
         send(owner, {:port, %{ref: ref}, port})
         {:noreply, state}
 
-      {:ok, %{"type" => "exit", "exit_code" => code}} ->
+      {:ok, %{"type" => "exit"} = message} ->
+        code = Map.get(message, "exit_code", 0)
+
         if state.using_control do
           send(owner, {:exit, %{ref: ref}, code})
           {:noreply, %{state | exit_code: code}}
@@ -579,8 +581,10 @@ defmodule Sprites.Command do
   defp drain_pending_frames(%{conn: conn} = state) do
     receive do
       {:gun_ws, ^conn, _stream_ref, {:binary, data}} ->
-        {:noreply, state} = handle_binary_frame(data, state)
-        drain_pending_frames(state)
+        case handle_binary_frame(data, state) do
+          {:noreply, state} -> drain_pending_frames(state)
+          {:stop, :normal, state} -> state
+        end
 
       {:gun_ws, ^conn, _stream_ref, {:text, json}} ->
         case handle_text_frame(json, state) do

--- a/lib/sprites/protocol.ex
+++ b/lib/sprites/protocol.ex
@@ -9,7 +9,7 @@ defmodule Sprites.Protocol do
     * 0 - stdin (client -> server)
     * 1 - stdout (server -> client)
     * 2 - stderr (server -> client)
-    * 3 - exit (server -> client, followed by 4-byte big-endian exit code)
+    * 3 - exit (server -> client, followed by a 1-byte exit code)
     * 4 - stdin EOF (client -> server)
 
   ## TTY Mode Protocol
@@ -40,7 +40,7 @@ defmodule Sprites.Protocol do
   @spec decode(binary()) :: decoded()
   def decode(<<@stdout_id, payload::binary>>), do: {:stdout, payload}
   def decode(<<@stderr_id, payload::binary>>), do: {:stderr, payload}
-  def decode(<<@exit_id, code::big-unsigned-32>>), do: {:exit, code}
+  def decode(<<@exit_id, code::unsigned-8>>), do: {:exit, code}
   def decode(<<@stdin_eof_id>>), do: {:stdin_eof, nil}
   def decode(data), do: {:unknown, data}
 

--- a/lib/sprites/protocol.ex
+++ b/lib/sprites/protocol.ex
@@ -9,7 +9,7 @@ defmodule Sprites.Protocol do
     * 0 - stdin (client -> server)
     * 1 - stdout (server -> client)
     * 2 - stderr (server -> client)
-    * 3 - exit (server -> client, followed by a 1-byte exit code)
+    * 3 - exit (server -> client, first payload byte is the exit code; defaults to 0)
     * 4 - stdin EOF (client -> server)
 
   ## TTY Mode Protocol
@@ -33,14 +33,15 @@ defmodule Sprites.Protocol do
   Returns a tuple of `{stream_type, payload}` where:
     * `{:stdout, binary}` - stdout data
     * `{:stderr, binary}` - stderr data
-    * `{:exit, integer}` - exit code
+    * `{:exit, integer}` - first payload byte as the exit code (defaults to 0 when omitted)
     * `{:stdin_eof, nil}` - stdin closed
     * `{:unknown, binary}` - unrecognized data
   """
   @spec decode(binary()) :: decoded()
   def decode(<<@stdout_id, payload::binary>>), do: {:stdout, payload}
   def decode(<<@stderr_id, payload::binary>>), do: {:stderr, payload}
-  def decode(<<@exit_id, code::unsigned-8>>), do: {:exit, code}
+  def decode(<<@exit_id, code::unsigned-8, _rest::binary>>), do: {:exit, code}
+  def decode(<<@exit_id>>), do: {:exit, 0}
   def decode(<<@stdin_eof_id>>), do: {:stdin_eof, nil}
   def decode(data), do: {:unknown, data}
 

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -1,0 +1,24 @@
+defmodule Sprites.CommandTest do
+  use ExUnit.Case, async: true
+
+  alias Sprites.Command
+
+  test "handles the exit_code field in text exit frames" do
+    ref = make_ref()
+
+    state = %{
+      using_control: true,
+      owner: self(),
+      ref: ref,
+      exit_code: nil
+    }
+
+    assert {:noreply, %{exit_code: 42}} =
+             Command.handle_info(
+               {:control_data, :text, ~s({"type":"exit","exit_code":42})},
+               state
+             )
+
+    assert_receive {:exit, %{ref: ^ref}, 42}
+  end
+end

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -1,17 +1,11 @@
 defmodule Sprites.CommandTest do
   use ExUnit.Case, async: true
 
-  alias Sprites.Command
+  alias Sprites.{Command, Protocol}
 
-  test "handles the exit_code field in text exit frames" do
-    ref = make_ref()
-
-    state = %{
-      using_control: true,
-      owner: self(),
-      ref: ref,
-      exit_code: nil
-    }
+  test "handles the exit_code field in control text exit frames" do
+    state = command_state(%{using_control: true})
+    ref = state.ref
 
     assert {:noreply, %{exit_code: 42}} =
              Command.handle_info(
@@ -20,5 +14,75 @@ defmodule Sprites.CommandTest do
              )
 
     assert_receive {:exit, %{ref: ^ref}, 42}
+  end
+
+  test "defaults a code-less control text exit frame to zero" do
+    state = command_state(%{using_control: true})
+    ref = state.ref
+
+    assert {:noreply, %{exit_code: 0}} =
+             Command.handle_info(
+               {:control_data, :text, ~s({"type":"exit"})},
+               state
+             )
+
+    assert_receive {:exit, %{ref: ^ref}, 0}
+  end
+
+  test "handles a code-less text exit frame in direct TTY mode" do
+    state = command_state(%{tty_mode: true})
+    ref = state.ref
+
+    assert {:stop, :normal, %{exit_code: 0}} =
+             Command.handle_info(
+               {:gun_ws, nil, make_ref(), {:text, ~s({"type":"exit"})}},
+               state
+             )
+
+    assert_receive {:exit, %{ref: ^ref}, 0}
+  end
+
+  test "handles a binary exit frame in direct mode" do
+    state = command_state()
+    ref = state.ref
+    frame = <<Protocol.exit_id(), 42>>
+
+    assert {:stop, :normal, %{exit_code: 42}} =
+             Command.handle_info({:gun_ws, nil, make_ref(), {:binary, frame}}, state)
+
+    assert_receive {:exit, %{ref: ^ref}, 42}
+  end
+
+  test "drains a pending direct binary exit before handling gun_down" do
+    state = command_state()
+    ref = state.ref
+    frame = <<Protocol.exit_id(), 0>>
+
+    send(self(), {:gun_ws, nil, make_ref(), {:binary, frame}})
+
+    assert {:stop, :normal, _state} =
+             Command.handle_info({:gun_down, nil, :http, :closed, []}, state)
+
+    assert_receive {:exit, %{ref: ^ref}, 0}
+    refute_receive {:error, %{ref: ^ref}, :closed}
+  end
+
+  defp command_state(overrides \\ %{}) do
+    Map.merge(
+      %{
+        owner: self(),
+        ref: make_ref(),
+        tty_mode: false,
+        conn: nil,
+        stream_ref: nil,
+        exit_code: nil,
+        token: nil,
+        sprite: nil,
+        url: nil,
+        using_control: false,
+        control_conn: nil
+      },
+      overrides
+    )
   end
 end

--- a/test/protocol_test.exs
+++ b/test/protocol_test.exs
@@ -1,0 +1,11 @@
+defmodule Sprites.ProtocolTest do
+  use ExUnit.Case, async: true
+
+  alias Sprites.Protocol
+
+  test "decodes the one-byte exit frame" do
+    assert Protocol.decode(<<Protocol.exit_id(), 0>>) == {:exit, 0}
+    assert Protocol.decode(<<Protocol.exit_id(), 42>>) == {:exit, 42}
+    assert Protocol.decode(<<Protocol.exit_id(), 255>>) == {:exit, 255}
+  end
+end

--- a/test/protocol_test.exs
+++ b/test/protocol_test.exs
@@ -8,4 +8,12 @@ defmodule Sprites.ProtocolTest do
     assert Protocol.decode(<<Protocol.exit_id(), 42>>) == {:exit, 42}
     assert Protocol.decode(<<Protocol.exit_id(), 255>>) == {:exit, 255}
   end
+
+  test "defaults a code-less exit frame to zero" do
+    assert Protocol.decode(<<Protocol.exit_id()>>) == {:exit, 0}
+  end
+
+  test "uses the first exit payload byte and ignores trailing bytes" do
+    assert Protocol.decode(<<Protocol.exit_id(), 42, 0, 255>>) == {:exit, 42}
+  end
 end


### PR DESCRIPTION
## Summary

- decode non-TTY exit frames using the protocol's first payload byte
- treat an empty binary exit payload and a code-less JSON exit as exit code 0
- tolerate trailing bytes in binary exit frames, matching the peer SDKs
- handle direct-mode exit frames safely while draining pending frames on `gun_down`
- add regression coverage for direct, control, TTY, and `gun_down` paths

## User impact

Commands record their exit status before the WebSocket closes, preventing successful calls from surfacing as `Command failed: :closed`. The decoder also handles empty or extended exit frames consistently with the Go, JavaScript, and Python SDKs.

## Validation

- focused suite: 8 tests passed
- full suite: 42 of 43 tests passed
- remaining failure is the pre-existing scaffold test that calls the undefined `Sprites.hello/0`
- live issue repros remain to be run before merge; this environment does not have `SPRITE_TOKEN` or `SPRITE_NAME` configured

## Versioning and deployment

This is a backwards-compatible SDK correction now that control mode is on `main`. The package manifest remains at `0.1.0`; include this fix in the next SDK release. No service deployment is required.

Fixes #6.
