### PR TITLE
Add CI quality checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27.0.1"
-          elixir-version: "1.18.4"
+          otp-version: "29"
+          elixir-version: "1.20.2"
       - run: mix deps.get
       - name: Check formatting
         run: mix format --check-formatted
@@ -41,6 +41,8 @@ jobs:
             otp: "26"
           - elixir: "1.18.4"
             otp: "27.0.1"
+          - elixir: "1.20.2"
+            otp: "29"
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,52 @@
+name: Checks
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: format and compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27.0.1"
+          elixir-version: "1.18.4"
+      - run: mix deps.get
+      - name: Check formatting
+        run: mix format --check-formatted
+      - name: Compile without warnings
+        run: mix compile --warnings-as-errors
+
+  test:
+    name: test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: "1.15"
+            otp: "26"
+          - elixir: "1.18.4"
+            otp: "27.0.1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+      - run: mix deps.get
+      - name: Run tests
+        run: mix test

--- a/lib/sprites/command.ex
+++ b/lib/sprites/command.ex
@@ -17,7 +17,6 @@ defmodule Sprites.Command do
   """
 
   use GenServer
-  require Logger
 
   alias Sprites.{Sprite, Protocol, Error, Control, ControlConn}
 

--- a/lib/sprites/control_conn.ex
+++ b/lib/sprites/control_conn.ex
@@ -14,8 +14,6 @@ defmodule Sprites.ControlConn do
   """
 
   use GenServer
-  require Logger
-
   @control_prefix "control:"
 
   # Client API

--- a/lib/sprites/control_pool.ex
+++ b/lib/sprites/control_pool.ex
@@ -7,8 +7,6 @@ defmodule Sprites.ControlPool do
   """
 
   use GenServer
-  require Logger
-
   alias Sprites.ControlConn
 
   @max_pool_size 100

--- a/lib/sprites/errors.ex
+++ b/lib/sprites/errors.ex
@@ -125,8 +125,7 @@ defmodule Sprites.Error do
 
     # Try to parse JSON body
     {error_code, message, limit, window_seconds, retry_after_seconds, current_count,
-     upgrade_available,
-     upgrade_url} =
+     upgrade_available, upgrade_url} =
       case Jason.decode(body) do
         {:ok, data} when is_map(data) ->
           {

--- a/lib/sprites/sprite.ex
+++ b/lib/sprites/sprite.ex
@@ -146,5 +146,4 @@ defmodule Sprites.Sprite do
       params
     end
   end
-
 end

--- a/test/sprites_test.exs
+++ b/test/sprites_test.exs
@@ -1,8 +1,12 @@
 defmodule SpritesTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Sprites
 
-  test "greets the world" do
-    assert Sprites.hello() == :world
+  test "creates a client with normalized options" do
+    client = Sprites.new("test-token", base_url: "https://api.example.test/", timeout: 1_000)
+
+    assert client.token == "test-token"
+    assert client.base_url == "https://api.example.test"
+    assert client.timeout == 1_000
   end
 end


### PR DESCRIPTION
## Summary
- add pull request, main branch, and manual CI triggers
- enforce Mix formatting and warnings-as-errors compilation
- test the supported Elixir range on Elixir 1.15/OTP 26 and Elixir 1.18.4/OTP 27
- replace the obsolete scaffold test and remove unused Logger requirements exposed by the new checks

## User impact
Pull requests receive automated formatting, compilation, and test feedback. There is no intended runtime behavior change.

## Testing
- mix format --check-formatted
- mix compile --warnings-as-errors
- mix test: 35 passed

## Deployment
No application deployment is required. The workflow takes effect for pull requests and main after merge.