### PR TITLE
Prepare sprites-ex for Hex publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish to Hex
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hex-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: hex
+
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@v7
+
+      - name: Set up Erlang and Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: "29"
+          elixir-version: "1.20.2"
+
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          project_version="$(elixir -e '
+            contents = File.read!("mix.exs")
+            [_, version] = Regex.run(~r/@version\s+"([^"]+)"/, contents)
+            IO.write(version)
+          ')"
+
+          if [[ "$tag_version" != "$project_version" ]]; then
+            echo "Tag version $tag_version does not match mix.exs version $project_version" >&2
+            exit 1
+          fi
+
+      - name: Install Hex and Rebar
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Run tests
+        run: mix test
+
+      - name: Publish package and documentation
+        run: mix hex.publish --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fly.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add `sprites` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:sprites, git: "https://github.com/superfly/sprites-ex.git"}
+    {:sprites, "~> 0.1.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule Sprites.MixProject do
       deps: deps(),
       name: "Sprites",
       description: "Elixir SDK for Sprites code container runtime",
+      package: package(),
       source_url: @source_url,
       docs: docs()
     ]
@@ -35,8 +36,16 @@ defmodule Sprites.MixProject do
 
   defp docs do
     [
-      main: "Sprites-Ex",
+      main: "readme",
+      source_ref: "v#{@version}",
       extras: ["README.md"]
+    ]
+  end
+
+  defp package do
+    [
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url}
     ]
   end
 end


### PR DESCRIPTION
## Summary

- add Hex package metadata and the Fly.io MIT license
- publish from version tags after verifying the tag matches `mix.exs`
- fix the HexDocs landing page and remove the stale generated test
- update installation instructions to use the Hex package

## User impact

Once a matching version tag is pushed, users can install `sprites` directly from Hex and browse correctly generated documentation on HexDocs.

## Deployment

Merging this PR does not publish a package. Publishing is triggered by pushing a tag matching `v*.*.*` (starting with `v0.1.0`). The workflow uses the `HEX_API_KEY` secret in the protected `hex` GitHub environment, which is restricted to version tags.

## Validation

- `mix format --check-formatted`
- `mix test` (23 tests, 0 failures)
- `mix docs`
- `mix hex.build`
- Hex publish dry run validated the package up to authentication