### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Sprites.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
   @source_url "https://github.com/superfly/sprites-ex"
 
   def project do


### PR DESCRIPTION
## Summary

- bump the Hex package version to 0.2.0
- align generated documentation links with the v0.2.0 source tag

## User impact

This prepares the first sprites-ex release containing automatic client attribution through client_signals.

## Deployment

After this PR merges, push the v0.2.0 tag from the merged main commit. The tag will trigger the Hex publishing workflow.

## Verification

- mix format --check-formatted
- mix test (48 tests)