### PR TITLE
Fix command close without exit status

### DIFF
--- a/lib/sprites/command.ex
+++ b/lib/sprites/command.ex
@@ -541,8 +541,13 @@ defmodule Sprites.Command do
     end
   end
 
-  defp handle_close_frame(_code, _reason, %{exit_code: nil, owner: owner, ref: ref} = state) do
-    send(owner, {:exit, %{ref: ref}, 0})
+  defp handle_close_frame(_code, _reason, %{exit_code: nil} = state) do
+    state = drain_pending_frames(state)
+
+    if state.exit_code == nil do
+      send(state.owner, {:error, %{ref: state.ref}, :closed_before_exit})
+    end
+
     {:stop, :normal, state}
   end
 
@@ -575,7 +580,7 @@ defmodule Sprites.Command do
   end
 
   # Drain any pending WebSocket frames from the mailbox.
-  # Called on gun_down to pick up exit frames that may have arrived
+  # Called when a connection closes to pick up exit frames that may have arrived
   # but not yet been processed (race between data frames and connection close).
   defp drain_pending_frames(%{conn: conn} = state) do
     receive do

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -67,6 +67,31 @@ defmodule Sprites.CommandTest do
     refute_receive {:error, %{ref: ^ref}, :closed}
   end
 
+  test "reports an error when a close frame arrives without an exit frame" do
+    state = command_state()
+    ref = state.ref
+
+    assert {:stop, :normal, %{exit_code: nil}} =
+             Command.handle_info({:gun_ws, nil, make_ref(), {:close, 1000, ""}}, state)
+
+    assert_receive {:error, %{ref: ^ref}, :closed_before_exit}
+    refute_receive {:exit, %{ref: ^ref}, 0}
+  end
+
+  test "drains a pending direct binary exit before handling a close frame" do
+    state = command_state()
+    ref = state.ref
+    frame = <<Protocol.exit_id(), 0>>
+
+    send(self(), {:gun_ws, nil, make_ref(), {:binary, frame}})
+
+    assert {:stop, :normal, %{exit_code: 0}} =
+             Command.handle_info({:gun_ws, nil, make_ref(), {:close, 1000, ""}}, state)
+
+    assert_receive {:exit, %{ref: ^ref}, 0}
+    refute_receive {:error, %{ref: ^ref}, :closed_before_exit}
+  end
+
   defp command_state(overrides \\ %{}) do
     Map.merge(
       %{


### PR DESCRIPTION
## Summary

- drain pending WebSocket frames when a close frame arrives
- report :closed_before_exit when the connection closes without an exit frame
- preserve a real pending exit status instead of reporting a transport error

## User impact

Commands whose WebSocket closes before delivering an exit status are now reported as errors instead of false successes with exit code 0. Callers can detect and retry the transport failure.

## Deployment

No service deployment is required. This behavior takes effect when consumers upgrade to a release containing this change.

## Testing

- mix test (50 tests, 0 failures)

Closes #19