### PR TITLE
Release v0.2.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Sprites.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
   @source_url "https://github.com/superfly/sprites-ex"
 
   def project do


### PR DESCRIPTION
## Summary

- Bump the Hex package version from 0.2.0 to 0.2.1.
- Prepare the package for a patch release containing the updated registry description.

## User impact

The next Hex publication will show the updated Sprites computers for agents description.

## Deployment

After this PR merges, pushing tag v0.2.1 will trigger the Publish to Hex workflow. The workflow verifies that the tag matches mix.exs before publishing.

## Testing

- mix format --check-formatted mix.exs
- mix test, 48 tests passed