### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Sprites.MixProject do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
   @source_url "https://github.com/superfly/sprites-ex"
 
   def project do


### PR DESCRIPTION
## Summary

- bump the Hex package version from 0.2.1 to 0.2.2

## User impact

This prepares the patch release that reports a command connection closing before an exit status as an error instead of a successful exit.

## Deployment

After this merges, push tag v0.2.2. The tag-triggered publish workflow will verify the tag against mix.exs, run the test suite, and publish the package and documentation to Hex.

## Testing

- mix format --check-formatted
- mix compile --warnings-as-errors
- mix test: 50 passed
- main GitHub Actions matrix passed on Elixir 1.15, 1.18.4, and 1.20.2
