### PR TITLE
Report provider session identity to opt-in command owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ Sprites.close_stdin(command)
 Sprites.resize(command, 40, 120)
 ```
 
+#### Provider session identity
+
+Asynchronous callers can opt into `session_info: true` to receive
+`{:session_info, %{ref: ref}, session_id}` from a provider `session_info` control
+frame. Match `ref` against `command.ref`. The ID is normalized to a string;
+duplicate identical frames produce one notification. Other metadata fields are
+not forwarded.
+
+Persist this identity with the intended sandbox and execution before using it
+for later attachment or termination. Missing metadata gives no identity. Invalid
+or conflicting IDs produce an error and close the local command transport;
+this does not confirm that the remote process stopped. Existing callers receive
+no additional messages unless they opt in.
+
 #### Streaming
 
 ```elixir

--- a/lib/sprites.ex
+++ b/lib/sprites.ex
@@ -143,6 +143,11 @@ defmodule Sprites do
     * `:tty` - Allocate a TTY (default: false)
     * `:tty_rows` - TTY rows (default: 24)
     * `:tty_cols` - TTY columns (default: 80)
+    * `:session_info` - Report provider session identity to the owner as
+      `{:session_info, %{ref: ref}, session_id}` (default: false). The ID is a
+      string. Missing metadata yields no identity; it is never inferred from
+      command output. Invalid or conflicting metadata ends the local command
+      with `:invalid_session_info` or `:conflicting_session_info`, respectively.
 
   ## Examples
 

--- a/lib/sprites/command.ex
+++ b/lib/sprites/command.ex
@@ -9,6 +9,8 @@ defmodule Sprites.Command do
     * `{:stderr, command, data}` - stderr data received
     * `{:exit, command, exit_code}` - command completed
     * `{:error, command, reason}` - error occurred
+    * `{:session_info, %{ref: ref}, session_id}` - provider session identity
+      (only when `session_info: true`; normalized to a string)
 
   Supports two execution modes:
 
@@ -134,6 +136,8 @@ defmodule Sprites.Command do
       owner: owner,
       ref: ref,
       tty_mode: tty_mode,
+      report_session_info: Keyword.get(opts, :session_info, false) == true,
+      session_id: nil,
       conn: nil,
       stream_ref: nil,
       exit_code: nil,
@@ -359,7 +363,7 @@ defmodule Sprites.Command do
       # been delivered but not yet processed.
       state = drain_pending_frames(state)
 
-      if state.exit_code == nil do
+      if state.exit_code == nil and is_nil(Map.get(state, :terminal_error)) do
         # Still no exit code after draining — report as error
         send(state.owner, {:error, %{ref: state.ref}, reason})
       end
@@ -516,6 +520,9 @@ defmodule Sprites.Command do
 
   defp handle_text_frame(json, %{owner: owner, ref: ref} = state) do
     case Jason.decode(json) do
+      {:ok, %{"type" => "session_info"} = message} ->
+        handle_session_info(message, state)
+
       {:ok, %{"type" => "port", "port" => port}} ->
         send(owner, {:port, %{ref: ref}, port})
         {:noreply, state}
@@ -541,10 +548,59 @@ defmodule Sprites.Command do
     end
   end
 
+  # Only provider control metadata establishes this identity. Never infer it
+  # from stdout, process argv, or a session listing that may contain neighbors.
+  defp handle_session_info(_message, %{exit_code: code} = state) when not is_nil(code),
+    do: {:noreply, state}
+
+  defp handle_session_info(message, %{report_session_info: true} = state) do
+    case {normalize_session_id(message["session_id"]), state.session_id} do
+      {{:ok, id}, nil} ->
+        send(state.owner, {:session_info, %{ref: state.ref}, id})
+        {:noreply, %{state | session_id: id}}
+
+      {{:ok, id}, id} ->
+        {:noreply, state}
+
+      {{:ok, _other}, _original} ->
+        session_info_error(state, :conflicting_session_info)
+
+      {:error, _} ->
+        session_info_error(state, :invalid_session_info)
+    end
+  end
+
+  defp handle_session_info(_message, state), do: {:noreply, state}
+
+  defp normalize_session_id(id) when is_integer(id) and id > 0,
+    do: {:ok, Integer.to_string(id)}
+
+  defp normalize_session_id(id) when is_binary(id) and byte_size(id) in 1..256 do
+    if Regex.match?(~r/\A[A-Za-z0-9_-]+\z/, id), do: {:ok, id}, else: :error
+  end
+
+  defp normalize_session_id(_), do: :error
+
+  defp session_info_error(state, reason) do
+    send(state.owner, {:error, %{ref: state.ref}, reason})
+
+    # An active control operation must not be returned to the reusable pool.
+    # The pool monitors this connection and removes it when it closes.
+    state =
+      if state.using_control and is_pid(state.control_conn) do
+        ControlConn.close(state.control_conn)
+        %{state | control_conn: nil}
+      else
+        state
+      end
+
+    {:stop, :normal, Map.put(state, :terminal_error, reason)}
+  end
+
   defp handle_close_frame(_code, _reason, %{exit_code: nil} = state) do
     state = drain_pending_frames(state)
 
-    if state.exit_code == nil do
+    if state.exit_code == nil and is_nil(Map.get(state, :terminal_error)) do
       send(state.owner, {:error, %{ref: state.ref}, :closed_before_exit})
     end
 

--- a/test/session_info_test.exs
+++ b/test/session_info_test.exs
@@ -1,0 +1,149 @@
+defmodule Sprites.SessionInfoTest do
+  use ExUnit.Case, async: true
+
+  alias Sprites.Command
+
+  defp state(overrides \\ %{}) do
+    Map.merge(
+      %{
+        owner: self(),
+        ref: make_ref(),
+        tty_mode: false,
+        conn: nil,
+        stream_ref: nil,
+        exit_code: nil,
+        using_control: false,
+        control_conn: nil,
+        report_session_info: true,
+        session_id: nil
+      },
+      overrides
+    )
+  end
+
+  defp direct(state, message) do
+    Command.handle_info({:gun_ws, nil, make_ref(), {:text, Jason.encode!(message)}}, state)
+  end
+
+  for {mode, id, normalized} <- [
+        {:direct, 19, "19"},
+        {:direct, "abc-123", "abc-123"},
+        {:tty, "42", "42"},
+        {:control, 19, "19"}
+      ] do
+    test "#{mode} reports #{inspect(id)} with the command ref and no other metadata" do
+      state = state(%{tty_mode: unquote(mode) == :tty, using_control: unquote(mode) == :control})
+      ref = state.ref
+      message = %{type: "session_info", session_id: unquote(id), command: "private command"}
+
+      frame =
+        if unquote(mode) == :control,
+          do: {:control_data, :text, Jason.encode!(message)},
+          else: {:gun_ws, nil, make_ref(), {:text, Jason.encode!(message)}}
+
+      assert {:noreply, %{session_id: unquote(normalized)}} = Command.handle_info(frame, state)
+      assert_receive {:session_info, %{ref: ^ref}, unquote(normalized)}
+      refute_receive {:session_info, _, _}
+    end
+  end
+
+  test "default callers receive no new messages, even for invalid metadata" do
+    state = state(%{report_session_info: false})
+    assert {:noreply, ^state} = direct(state, %{type: "session_info", session_id: 19})
+    assert {:noreply, ^state} = direct(state, %{type: "session_info"})
+    refute_receive {:session_info, _, _}
+    refute_receive {:error, _, _}
+  end
+
+  test "repeated normalized identity is emitted once" do
+    state = state()
+    ref = state.ref
+    {:noreply, state} = direct(state, %{type: "session_info", session_id: 19})
+    assert_receive {:session_info, %{ref: ^ref}, "19"}
+    assert {:noreply, ^state} = direct(state, %{type: "session_info", session_id: "19"})
+    refute_receive {:session_info, _, _}
+  end
+
+  test "a conflicting identity fails without replacing the original" do
+    state = state(%{session_id: "19"})
+    ref = state.ref
+
+    assert {:stop, :normal, %{session_id: "19", terminal_error: :conflicting_session_info}} =
+             direct(state, %{type: "session_info", session_id: "20"})
+
+    assert_receive {:error, %{ref: ^ref}, :conflicting_session_info}
+    refute_receive {:session_info, _, _}
+    refute_receive {:exit, _, _}
+  end
+
+  for id <- [nil, "", 0, -1, 1.5, [], %{}, "../19", "a?b", String.duplicate("x", 257)] do
+    test "invalid session ID #{inspect(id, printable_limit: 16)} cannot become identity or success" do
+      state = state()
+      ref = state.ref
+
+      assert {:stop, :normal, %{terminal_error: :invalid_session_info}} =
+               direct(state, %{type: "session_info", session_id: unquote(Macro.escape(id))})
+
+      assert_receive {:error, %{ref: ^ref}, :invalid_session_info}
+      refute_receive {:session_info, _, _}
+      refute_receive {:exit, _, _}
+    end
+  end
+
+  test "invalid control metadata closes the connection instead of returning it to the pool" do
+    state = state(%{using_control: true, control_conn: self()})
+    ref = state.ref
+
+    assert {:stop, :normal, %{control_conn: nil, terminal_error: :invalid_session_info}} =
+             Command.handle_info({:control_data, :text, ~s({"type":"session_info"})}, state)
+
+    assert_receive {:error, %{ref: ^ref}, :invalid_session_info}
+    assert_receive {:"$gen_cast", :close}
+  end
+
+  test "metadata after an already reported control exit cannot emit another terminal frame" do
+    state = state(%{using_control: true, exit_code: 7})
+    assert {:noreply, ^state} = direct(state, %{type: "session_info"})
+    refute_receive {:error, _, _}
+    refute_receive {:session_info, _, _}
+  end
+
+  for closing <- [:close, :down] do
+    test "metadata failure drained during #{closing} emits exactly one error" do
+      state = state()
+      ref = state.ref
+      send(self(), {:gun_ws, nil, make_ref(), {:text, ~s({"type":"session_info"})}})
+
+      frame =
+        if unquote(closing) == :close,
+          do: {:gun_ws, nil, make_ref(), {:close, 1000, ""}},
+          else: {:gun_down, nil, :http, :closed, []}
+
+      assert {:stop, :normal, _state} = Command.handle_info(frame, state)
+
+      assert_receive {:error, %{ref: ^ref}, :invalid_session_info}
+      refute_receive {:error, %{ref: ^ref}, _}
+      refute_receive {:exit, %{ref: ^ref}, _}
+    end
+  end
+
+  test "missing provider metadata and lookalike stdout never invent identity" do
+    state = state()
+    ref = state.ref
+    text = Jason.encode!(%{type: "session_info", session_id: 19})
+
+    assert {:noreply, ^state} =
+             Command.handle_info(
+               {:gun_ws, nil, make_ref(), {:binary, <<1, text::binary>>}},
+               state
+             )
+
+    assert_receive {:stdout, %{ref: ^ref}, ^text}
+
+    assert {:stop, :normal, %{session_id: nil, exit_code: 7}} =
+             Command.handle_info({:gun_ws, nil, make_ref(), {:binary, <<3, 7>>}}, state)
+
+    assert_receive {:exit, %{ref: ^ref}, 7}
+    refute_receive {:session_info, _, _}
+  end
+end


### PR DESCRIPTION
`Sprites.Command` currently drops provider `session_info` frames. A host cannot persist the session ID associated with its command before later attachment or termination; discovering a neighboring session by listing or parsing command output does not supply that identity.

Add opt-in `session_info: true` owner notifications: `{:session_info, %{ref: ref}, session_id}`. Normalize IDs to strings, omit other provider metadata, suppress identical duplicates, and reject invalid or conflicting IDs without reporting success. Malformed metadata during socket shutdown emits one error; an active control connection is discarded rather than returned to the pool. Default callers receive no extra messages.

Validation: format, compilation with warnings as errors, and **72 tests, 0 failures** on Elixir 1.19.2 / OTP 28.3. A separate Elixir VM also received the real provider ID, used it to terminate an isolated process after disconnect, preserved a neighboring process (expected exit 7), and verified sandbox deletion. No running application VM was modified.

This exposes identity only. The host still owns authorization, durable intent, deadlines, and recovery. No package version bump is included; release timing remains with the maintainers.
