### PR TITLE
Bump version to 0.2.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Sprites.MixProject do
   use Mix.Project
 
-  @version "0.2.2"
+  @version "0.2.3"
   @source_url "https://github.com/superfly/sprites-ex"
 
   def project do


### PR DESCRIPTION
Bump the Hex package version from `0.2.2` to `0.2.3`. This release includes opt-in command session identity reporting and dependency updates while retaining Elixir 1.15 / OTP 26 support. The version also sets the documentation source reference to `v0.2.3`.

Validation: all 72 repository tests pass on Elixir 1.18.4 / OTP 27.0.1, `mix hex.build` successfully builds `sprites` 0.2.3, and formatting passes with CI's Elixir 1.20.2 toolchain. The PR workflow checks all three supported Elixir/OTP combinations. The external SDK integration harness, which requires a separate checkout and live service credentials, was not run.

After merging, push a `v0.2.3` tag on the merged commit to trigger the existing Publish to Hex workflow. Merging this PR alone does not publish the package.
