### PR TITLE
Verify TLS on proxy connections

### DIFF
--- a/lib/sprites/command.ex
+++ b/lib/sprites/command.ex
@@ -236,20 +236,7 @@ defmodule Sprites.Command do
     host = String.to_charlist(uri.host)
     port = uri.port || if(uri.scheme == "wss", do: 443, else: 80)
 
-    transport = if uri.scheme == "wss", do: :tls, else: :tcp
-
-    gun_opts = %{
-      protocols: [:http],
-      transport: transport,
-      tls_opts: [
-        verify: :verify_peer,
-        cacerts: :public_key.cacerts_get(),
-        depth: 3,
-        customize_hostname_check: [
-          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-        ]
-      ]
-    }
+    gun_opts = Sprites.Transport.gun_opts(uri.scheme)
 
     case :gun.open(host, port, gun_opts) do
       {:ok, conn} ->

--- a/lib/sprites/control_conn.ex
+++ b/lib/sprites/control_conn.ex
@@ -257,20 +257,7 @@ defmodule Sprites.ControlConn do
     host = String.to_charlist(uri.host)
     port = uri.port || if(uri.scheme == "wss", do: 443, else: 80)
 
-    transport = if uri.scheme == "wss", do: :tls, else: :tcp
-
-    gun_opts = %{
-      protocols: [:http],
-      transport: transport,
-      tls_opts: [
-        verify: :verify_peer,
-        cacerts: :public_key.cacerts_get(),
-        depth: 3,
-        customize_hostname_check: [
-          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-        ]
-      ]
-    }
+    gun_opts = Sprites.Transport.gun_opts(uri.scheme)
 
     case :gun.open(host, port, gun_opts) do
       {:ok, conn} ->

--- a/lib/sprites/proxy.ex
+++ b/lib/sprites/proxy.ex
@@ -147,16 +147,7 @@ defmodule Sprites.Proxy do
       # Connect via gun
       {:ok, {scheme, host, port, path}} = parse_ws_url(ws_url)
 
-      opts =
-        if scheme == :wss do
-          %{
-            protocols: [:http],
-            transport: :tls,
-            tls_opts: [verify: :verify_none]
-          }
-        else
-          %{protocols: [:http]}
-        end
+      opts = Sprites.Transport.gun_opts(Atom.to_string(scheme))
 
       case :gun.open(host, port, opts) do
         {:ok, conn} ->

--- a/lib/sprites/transport.ex
+++ b/lib/sprites/transport.ex
@@ -1,0 +1,25 @@
+defmodule Sprites.Transport do
+  @moduledoc false
+
+  @doc """
+  Options for `:gun.open/3` given a URL scheme. TLS connections verify the
+  server certificate against the system root store and check the hostname.
+  """
+  @spec gun_opts(String.t()) :: map()
+  def gun_opts("wss") do
+    %{
+      protocols: [:http],
+      transport: :tls,
+      tls_opts: [
+        verify: :verify_peer,
+        cacerts: :public_key.cacerts_get(),
+        depth: 3,
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    }
+  end
+
+  def gun_opts(_scheme), do: %{protocols: [:http], transport: :tcp}
+end

--- a/test/transport_test.exs
+++ b/test/transport_test.exs
@@ -1,0 +1,18 @@
+defmodule Sprites.TransportTest do
+  use ExUnit.Case, async: true
+
+  alias Sprites.Transport
+
+  test "wss connections verify the server certificate against system roots" do
+    opts = Transport.gun_opts("wss")
+
+    assert opts.transport == :tls
+    assert opts.tls_opts[:verify] == :verify_peer
+    assert opts.tls_opts[:cacerts] != nil
+    assert opts.tls_opts[:customize_hostname_check][:match_fun] != nil
+  end
+
+  test "ws connections use plain tcp" do
+    assert Transport.gun_opts("ws") == %{protocols: [:http], transport: :tcp}
+  end
+end


### PR DESCRIPTION
The port-forwarding proxy opened its WebSocket to the API with verify_none, so the bearer token it sends could be captured by anyone able to intercept the connection. Command and control connections already verified the server certificate; move that configuration into Sprites.Transport and use it for all three.