### PR TITLE
Fix proxy connection ownership and cleanup

### DIFF
--- a/lib/sprites/proxy.ex
+++ b/lib/sprites/proxy.ex
@@ -27,267 +27,323 @@ defmodule Sprites.Proxy do
   end
 
   defmodule Session do
-    @moduledoc """
-    Active proxy session managed by a GenServer.
-    """
+    @moduledoc "An owned, local TCP listener for Sprite proxy connections."
     use GenServer
+    @connect_timeout 10_000
+    @derive {Inspect, except: [:client]}
+    defstruct [
+      :local_port,
+      :remote_port,
+      :remote_host,
+      :listener,
+      :client,
+      :sprite_name,
+      :acceptor,
+      connections: %{},
+      sockets: %{}
+    ]
 
-    defstruct [:local_port, :remote_port, :remote_host, :listener, :client, :sprite_name]
-
-    @type t :: %__MODULE__{
-            local_port: non_neg_integer(),
-            remote_port: non_neg_integer(),
-            remote_host: String.t(),
-            listener: :gen_tcp.socket() | nil,
-            client: Client.t(),
-            sprite_name: String.t()
-          }
-
-    @doc """
-    Starts a proxy session.
-    """
+    @type t :: %__MODULE__{}
     @spec start_link(Client.t(), String.t(), PortMapping.t()) :: GenServer.on_start()
     def start_link(client, sprite_name, mapping) do
       GenServer.start_link(__MODULE__, {client, sprite_name, mapping})
     end
 
-    @doc """
-    Stops a proxy session.
-    """
     @spec stop(pid()) :: :ok
     def stop(pid) do
       GenServer.stop(pid, :normal)
     end
 
-    @doc """
-    Gets the local address the proxy is listening on.
-    """
     @spec local_addr(pid()) ::
             {:ok, :inet.socket_address(), :inet.port_number()} | {:error, term()}
     def local_addr(pid) do
       GenServer.call(pid, :local_addr)
     end
 
-    # GenServer callbacks
-
-    @impl true
     def init({client, sprite_name, %PortMapping{} = mapping}) do
-      # Start listening on local port
+      Process.flag(:trap_exit, true)
+
       case :gen_tcp.listen(mapping.local_port, [
              :binary,
-             {:packet, :raw},
-             {:active, false},
-             {:reuseaddr, true},
-             {:ip, {127, 0, 0, 1}}
+             packet: :raw,
+             active: false,
+             reuseaddr: true,
+             ip: {127, 0, 0, 1},
+             send_timeout: 5_000,
+             send_timeout_close: true
            ]) do
         {:ok, listener} ->
-          state = %__MODULE__{
-            local_port: mapping.local_port,
-            remote_port: mapping.remote_port,
-            remote_host: mapping.remote_host || "localhost",
-            listener: listener,
-            client: client,
-            sprite_name: sprite_name
-          }
+          server = self()
+          acceptor = spawn_link(fn -> accept_loop(server, listener) end)
 
-          # Start acceptor process
-          spawn_link(fn -> accept_loop(self(), listener) end)
-
-          {:ok, state}
+          {:ok,
+           %__MODULE__{
+             local_port: mapping.local_port,
+             remote_port: mapping.remote_port,
+             remote_host: mapping.remote_host || "localhost",
+             listener: listener,
+             client: client,
+             sprite_name: sprite_name,
+             acceptor: acceptor
+           }}
 
         {:error, reason} ->
           {:stop, {:listen_failed, reason}}
       end
     end
 
-    @impl true
-    def handle_call(:local_addr, _from, %{listener: listener} = state) do
-      case :inet.sockname(listener) do
-        {:ok, {addr, port}} -> {:reply, {:ok, addr, port}, state}
-        {:error, reason} -> {:reply, {:error, reason}, state}
+    def handle_call(:local_addr, _from, state) do
+      reply =
+        case :inet.sockname(state.listener) do
+          {:ok, {addr, port}} -> {:ok, addr, port}
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:reply, reply, state}
+    end
+
+    def handle_cast({:new_connection, socket}, state) do
+      case open_connection(state) do
+        {:ok, conn} ->
+          connection = %{
+            socket: socket,
+            stream: nil,
+            phase: :connecting,
+            monitor: Process.monitor(conn),
+            timer: Process.send_after(self(), {:connect_timeout, conn}, @connect_timeout)
+          }
+
+          state = %{
+            state
+            | connections: Map.put(state.connections, conn, connection),
+              sockets: Map.put(state.sockets, socket, conn)
+          }
+
+          {:noreply, state}
+
+        {:error, _reason} ->
+          :gen_tcp.close(socket)
+          {:noreply, state}
       end
     end
 
-    @impl true
-    def handle_cast({:new_connection, socket}, state) do
-      # Handle new connection in a separate process
-      spawn(fn -> handle_connection(socket, state) end)
+    def handle_info({:gun_up, conn, _protocol}, state) do
+      case Map.fetch(state.connections, conn) do
+        {:ok, %{phase: :connecting} = connection} ->
+          path = "/v1/sprites/#{URI.encode(state.sprite_name, &URI.char_unreserved?/1)}/proxy"
+
+          stream =
+            :gun.ws_upgrade(conn, path, ClientSignals.auth_headers(state.client.token), %{flow: 1})
+
+          {:noreply, put_connection(state, conn, %{connection | stream: stream, phase: :upgrade})}
+
+        _other ->
+          {:noreply, state}
+      end
+    end
+
+    def handle_info({:gun_upgrade, conn, stream, ["websocket"], _headers}, state) do
+      case Map.fetch(state.connections, conn) do
+        {:ok, %{stream: ^stream, phase: :upgrade} = connection} ->
+          :gun.ws_send(
+            conn,
+            stream,
+            {:text, Jason.encode!(%{host: state.remote_host, port: state.remote_port})}
+          )
+
+          {:noreply, put_connection(state, conn, %{connection | phase: :initializing})}
+
+        _other ->
+          {:noreply, close_connection(state, conn)}
+      end
+    end
+
+    def handle_info({:gun_ws, conn, stream, {:text, response}}, state) do
+      case Map.fetch(state.connections, conn) do
+        {:ok, %{stream: ^stream, phase: :initializing} = connection} ->
+          case Jason.decode(response) do
+            {:ok, %{"status" => "connected"}} ->
+              Process.cancel_timer(connection.timer)
+
+              case :inet.setopts(connection.socket, active: :once) do
+                :ok ->
+                  :gun.update_flow(conn, stream, 1)
+
+                  {:noreply,
+                   put_connection(state, conn, %{connection | phase: :ready, timer: nil})}
+
+                {:error, _reason} ->
+                  {:noreply, close_connection(state, conn)}
+              end
+
+            _other ->
+              {:noreply, close_connection(state, conn)}
+          end
+
+        _other ->
+          {:noreply, close_connection(state, conn)}
+      end
+    end
+
+    def handle_info({:gun_ws, conn, stream, {:binary, data}}, state) do
+      case Map.fetch(state.connections, conn) do
+        {:ok, %{stream: ^stream, phase: :ready} = connection} ->
+          case :gen_tcp.send(connection.socket, data) do
+            :ok ->
+              :gun.update_flow(conn, stream, 1)
+              {:noreply, state}
+
+            {:error, _reason} ->
+              {:noreply, close_connection(state, conn)}
+          end
+
+        _other ->
+          {:noreply, close_connection(state, conn)}
+      end
+    end
+
+    def handle_info({:tcp, socket, data}, state) do
+      with {:ok, conn} <- Map.fetch(state.sockets, socket),
+           %{stream: stream, phase: :ready} <- Map.fetch!(state.connections, conn),
+           :ok <- send_frame(conn, stream, data),
+           :ok <- :inet.setopts(socket, active: :once) do
+        {:noreply, state}
+      else
+        _other -> {:noreply, close_socket(state, socket)}
+      end
+    end
+
+    def handle_info({:tcp_closed, socket}, state) do
+      {:noreply, close_socket(state, socket)}
+    end
+
+    def handle_info({:tcp_error, socket, _reason}, state) do
+      {:noreply, close_socket(state, socket)}
+    end
+
+    def handle_info({:gun_ws, conn, _stream, _frame}, state) do
+      {:noreply, close_connection(state, conn)}
+    end
+
+    def handle_info({:gun_response, conn, _stream, _fin, _status, _headers}, state) do
+      {:noreply, close_connection(state, conn)}
+    end
+
+    def handle_info({:gun_error, conn, _stream, _reason}, state) do
+      {:noreply, close_connection(state, conn)}
+    end
+
+    def handle_info({:gun_error, conn, _reason}, state) do
+      {:noreply, close_connection(state, conn)}
+    end
+
+    def handle_info({:gun_down, conn, _protocol, _reason, _streams}, state) do
+      {:noreply, close_connection(state, conn)}
+    end
+
+    def handle_info({:DOWN, _ref, :process, conn, _reason}, state) do
+      {:noreply, close_connection(state, conn)}
+    end
+
+    def handle_info({:connect_timeout, conn}, state) do
+      case Map.fetch(state.connections, conn) do
+        {:ok, %{phase: :ready}} -> {:noreply, state}
+        _other -> {:noreply, close_connection(state, conn)}
+      end
+    end
+
+    def handle_info({:EXIT, acceptor, _reason}, %{acceptor: acceptor} = state) do
+      {:stop, :acceptor_closed, state}
+    end
+
+    def handle_info(_message, state) do
       {:noreply, state}
     end
 
-    @impl true
-    def terminate(_reason, %{listener: listener}) do
-      if listener do
-        :gen_tcp.close(listener)
-      end
-
+    def terminate(_reason, state) do
+      :gen_tcp.close(state.listener)
+      Enum.each(Map.keys(state.connections), &close_connection(state, &1))
       :ok
     end
 
-    # Private functions
+    def format_status(status) do
+      # OTP 25+ uses this callback, including Elixir 1.15 applications.
+      Map.merge(status, %{state: :redacted, message: :redacted, reason: :redacted, log: []})
+    end
 
     defp accept_loop(server, listener) do
       case :gen_tcp.accept(listener) do
         {:ok, socket} ->
-          GenServer.cast(server, {:new_connection, socket})
-          accept_loop(server, listener)
-
-        {:error, :closed} ->
-          :ok
-
-        {:error, _reason} ->
-          accept_loop(server, listener)
-      end
-    end
-
-    defp handle_connection(local_socket, state) do
-      # Build WebSocket URL
-      ws_url = build_proxy_url(state)
-
-      # Connect via gun
-      {:ok, {scheme, host, port, path}} = parse_ws_url(ws_url)
-
-      opts = Sprites.Transport.gun_opts(Atom.to_string(scheme))
-
-      case :gun.open(host, port, opts) do
-        {:ok, conn} ->
-          case :gun.await_up(conn, 10_000) do
-            {:ok, _protocol} ->
-              headers = ClientSignals.auth_headers(state.client.token)
-
-              stream_ref = :gun.ws_upgrade(conn, path, headers, %{})
-
-              receive do
-                {:gun_upgrade, ^conn, ^stream_ref, ["websocket"], _headers} ->
-                  # Send init message
-                  init_msg =
-                    Jason.encode!(%{
-                      host: state.remote_host,
-                      port: state.remote_port
-                    })
-
-                  :gun.ws_send(conn, stream_ref, {:text, init_msg})
-
-                  # Wait for response
-                  receive do
-                    {:gun_ws, ^conn, ^stream_ref, {:text, response}} ->
-                      case Jason.decode(response) do
-                        {:ok, %{"status" => "connected"}} ->
-                          # Start bidirectional proxy
-                          proxy_loop(local_socket, conn, stream_ref)
-
-                        {:ok, %{"status" => status}} ->
-                          :gen_tcp.close(local_socket)
-                          :gun.close(conn)
-                          {:error, {:proxy_failed, status}}
-
-                        {:error, _} ->
-                          :gen_tcp.close(local_socket)
-                          :gun.close(conn)
-                          {:error, :invalid_response}
-                      end
-
-                    {:gun_ws, ^conn, ^stream_ref, {:close, _, _}} ->
-                      :gen_tcp.close(local_socket)
-                      :gun.close(conn)
-                      {:error, :connection_closed}
-                  after
-                    10_000 ->
-                      :gen_tcp.close(local_socket)
-                      :gun.close(conn)
-                      {:error, :timeout}
-                  end
-
-                {:gun_response, ^conn, ^stream_ref, :nofin, status, _headers} ->
-                  :gen_tcp.close(local_socket)
-                  :gun.close(conn)
-                  {:error, {:upgrade_failed, status}}
-
-                {:gun_error, ^conn, ^stream_ref, reason} ->
-                  :gen_tcp.close(local_socket)
-                  :gun.close(conn)
-                  {:error, reason}
-              after
-                10_000 ->
-                  :gen_tcp.close(local_socket)
-                  :gun.close(conn)
-                  {:error, :upgrade_timeout}
-              end
-
-            {:error, reason} ->
-              :gen_tcp.close(local_socket)
-              :gun.close(conn)
-              {:error, reason}
+          case :gen_tcp.controlling_process(socket, server) do
+            :ok -> GenServer.cast(server, {:new_connection, socket})
+            {:error, _reason} -> :gen_tcp.close(socket)
           end
 
-        {:error, reason} ->
-          :gen_tcp.close(local_socket)
-          {:error, reason}
-      end
-    end
+          accept_loop(server, listener)
 
-    defp proxy_loop(local_socket, ws_conn, stream_ref) do
-      # Set local socket to active mode
-      :inet.setopts(local_socket, [{:active, true}])
-
-      do_proxy_loop(local_socket, ws_conn, stream_ref)
-    end
-
-    defp do_proxy_loop(local_socket, ws_conn, stream_ref) do
-      receive do
-        # Data from local socket -> send to WebSocket
-        {:tcp, ^local_socket, data} ->
-          :gun.ws_send(ws_conn, stream_ref, {:binary, data})
-          do_proxy_loop(local_socket, ws_conn, stream_ref)
-
-        # Local socket closed
-        {:tcp_closed, ^local_socket} ->
-          :gun.close(ws_conn)
-          :ok
-
-        {:tcp_error, ^local_socket, _reason} ->
-          :gun.close(ws_conn)
-          :ok
-
-        # Data from WebSocket -> send to local socket
-        {:gun_ws, ^ws_conn, ^stream_ref, {:binary, data}} ->
-          :gen_tcp.send(local_socket, data)
-          do_proxy_loop(local_socket, ws_conn, stream_ref)
-
-        # WebSocket closed
-        {:gun_ws, ^ws_conn, ^stream_ref, {:close, _, _}} ->
-          :gen_tcp.close(local_socket)
-          :gun.close(ws_conn)
-          :ok
-
-        {:gun_down, ^ws_conn, _, _, _} ->
-          :gen_tcp.close(local_socket)
-          :ok
-
-        {:gun_error, ^ws_conn, _, _reason} ->
-          :gen_tcp.close(local_socket)
-          :gun.close(ws_conn)
+        {:error, _reason} ->
           :ok
       end
     end
 
-    defp build_proxy_url(state) do
-      base_url =
-        state.client.base_url
-        |> String.replace(~r/^http/, "ws")
+    defp open_connection(state) do
+      uri = URI.parse(state.client.base_url)
 
-      "#{base_url}/v1/sprites/#{URI.encode(state.sprite_name)}/proxy"
+      scheme =
+        if uri.scheme == "https" do
+          "wss"
+        else
+          "ws"
+        end
+
+      opts = Sprites.Transport.gun_opts(scheme) |> Map.put(:retry, 0)
+      :gun.open(String.to_charlist(uri.host), uri.port, opts)
+    rescue
+      _error -> {:error, :connection_failed}
+    catch
+      :exit, _reason -> {:error, :connection_failed}
     end
 
-    defp parse_ws_url(url) do
-      uri = URI.parse(url)
+    defp send_frame(conn, stream, data) do
+      :gun.ws_send(conn, stream, {:binary, data})
+      # Wait until Gun handles the send before accepting another TCP message.
+      :gun.info(conn)
+      :ok
+    catch
+      :exit, _reason -> {:error, :connection_closed}
+    end
 
-      scheme = if uri.scheme == "wss", do: :wss, else: :ws
-      host = String.to_charlist(uri.host)
-      port = uri.port || if(scheme == :wss, do: 443, else: 80)
-      path = String.to_charlist(uri.path || "/")
+    defp put_connection(state, conn, connection) do
+      %{state | connections: Map.put(state.connections, conn, connection)}
+    end
 
-      {:ok, {scheme, host, port, path}}
+    defp close_socket(state, socket) do
+      case Map.fetch(state.sockets, socket) do
+        {:ok, conn} -> close_connection(state, conn)
+        :error -> state
+      end
+    end
+
+    defp close_connection(state, conn) do
+      case Map.pop(state.connections, conn) do
+        {nil, _connections} ->
+          state
+
+        {connection, connections} ->
+          if connection.timer do
+            Process.cancel_timer(connection.timer)
+          end
+
+          Process.demonitor(connection.monitor, [:flush])
+          :gen_tcp.close(connection.socket)
+          :gun.close(conn)
+
+          %{
+            state
+            | connections: connections,
+              sockets: Map.delete(state.sockets, connection.socket)
+          }
+      end
     end
   end
 

--- a/test/proxy_test.exs
+++ b/test/proxy_test.exs
@@ -1,0 +1,315 @@
+defmodule Sprites.ProxyTest do
+  use ExUnit.Case, async: false
+
+  alias Sprites.Proxy.Session
+  import ExUnit.CaptureLog
+
+  @token "synthetic-sprites-token"
+
+  test "relays HTTP in both directions without forwarding the platform token" do
+    {port, server} =
+      server(fn socket, owner ->
+        {headers, socket} = upgrade(socket)
+        assert headers =~ "authorization: Bearer #{@token}"
+        assert {:text, init} = frame(socket)
+        assert Jason.decode!(init) == %{"host" => "localhost", "port" => 8642}
+        send_frame(socket, {:text, ~s({"status":"connected"})})
+        assert {:binary, request} = frame(socket)
+        assert request =~ "authorization: Bearer hermes-key"
+        refute request =~ @token
+        send_frame(socket, {:binary, "HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok"})
+        send(owner, :relayed)
+        assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+      end)
+
+    session = start_proxy(port)
+    {:ok, {127, 0, 0, 1}, local_port} = Session.local_addr(session)
+
+    assert {:ok, %{status: 200, body: "ok"}} =
+             Req.get("http://127.0.0.1:#{local_port}",
+               auth: {:bearer, "hermes-key"},
+               receive_timeout: 1_000,
+               retry: false,
+               finch: [pool_timeout: 1_000]
+             )
+
+    assert_receive :relayed
+    Session.stop(session)
+    assert_receive {:DOWN, _, :process, ^server, :normal}
+  end
+
+  test "stop closes a pending handshake and its local socket" do
+    {port, server} =
+      server(fn socket, owner ->
+        assert {:ok, _headers} = :gen_tcp.recv(socket, 0, 1_000)
+        send(owner, :handshake_pending)
+        assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+      end)
+
+    session = start_proxy(port)
+    socket = connect(session)
+    assert_receive :handshake_pending, 1_000
+    Session.stop(session)
+    assert {:error, :closed} = :gen_tcp.recv(socket, 0, 1_000)
+    assert_receive {:DOWN, _, :process, ^server, :normal}
+  end
+
+  test "parent death closes an active tunnel" do
+    {port, server} =
+      server(fn socket, owner ->
+        upgrade(socket)
+        assert {:text, _init} = frame(socket)
+        send_frame(socket, {:text, ~s({"status":"connected"})})
+        send(owner, :connected)
+        assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+      end)
+
+    test = self()
+
+    owner =
+      start_supervised!(
+        {Task,
+         fn ->
+           client = Sprites.new(@token, base_url: "http://127.0.0.1:#{port}")
+           {:ok, session} = Sprites.proxy_port(Sprites.sprite(client, "test"), 0, 8642)
+           send(test, {:session, session})
+           receive do: (:stop -> :ok)
+         end}
+      )
+
+    assert_receive {:session, session}
+    monitor = Process.monitor(session)
+    socket = connect(session)
+    assert_receive :connected, 1_000
+
+    log =
+      capture_log(fn ->
+        Process.exit(owner, :kill)
+        assert_receive {:DOWN, ^monitor, :process, ^session, _reason}, 1_000
+      end)
+
+    assert log =~ "redacted"
+    refute log =~ @token
+    refute log =~ "Bearer"
+    assert {:error, :closed} = :gen_tcp.recv(socket, 0, 1_000)
+    assert_receive {:DOWN, _, :process, ^server, :normal}
+  end
+
+  test "state inspection does not expose the platform credential" do
+    session = start_proxy(1)
+    refute inspect(:sys.get_state(session)) =~ @token
+    refute inspect(:sys.get_status(session)) =~ @token
+  end
+
+  test "a paused consumer bounds incoming frames and resumes delivery" do
+    {port, server} =
+      server(fn socket, owner ->
+        upgrade(socket)
+        frame(socket)
+        send_frame(socket, {:text, ~s({"status":"connected"})})
+        assert {:binary, "ready"} = frame(socket)
+        send(owner, :ready)
+        receive do: (:first -> send_frame(socket, {:binary, "a"}))
+
+        receive do
+          :remaining ->
+            Enum.each(1..100, fn _ -> send_frame(socket, {:binary, "b"}) end)
+            send(owner, :sent)
+        end
+
+        assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+      end)
+
+    session = start_proxy(port)
+    socket = connect(session)
+    :ok = :gen_tcp.send(socket, "ready")
+    assert_receive :ready, 1_000
+    [conn] = Map.keys(:sys.get_state(session).connections)
+    :erlang.trace(conn, true, [:send])
+    :sys.suspend(session)
+
+    try do
+      send(server, :first)
+      assert_receive {:trace, ^conn, :send, {:gun_ws, ^conn, _, {:binary, "a"}}, ^session}, 1_000
+      send(server, :remaining)
+      assert_receive :sent, 1_000
+      :gun.info(conn)
+      {:messages, messages} = Process.info(session, :messages)
+      assert Enum.count(messages, &match?({:gun_ws, _, _, {:binary, _}}, &1)) == 1
+    after
+      :erlang.trace(conn, false, [:send])
+      :sys.resume(session)
+    end
+
+    assert {:ok, payload} = :gen_tcp.recv(socket, 101, 1_000)
+    assert payload == "a" <> String.duplicate("b", 100)
+    monitor = Process.monitor(conn)
+    Session.stop(session)
+    assert_receive {:DOWN, ^monitor, :process, ^conn, _reason}
+    assert {:error, :closed} = :gen_tcp.recv(socket, 0, 1_000)
+    assert_receive {:DOWN, _, :process, ^server, :normal}
+  end
+
+  for failure <- [:upgrade, :init, :timeout] do
+    @tag failure: failure
+    test "#{failure} failure closes both sockets without logging remote secrets", %{
+      failure: failure
+    } do
+      remote_secret = "remote-body-secret"
+
+      {port, server} =
+        server(fn socket, owner ->
+          if failure == :init do
+            upgrade(socket)
+            frame(socket)
+          else
+            assert {:ok, _headers} = :gen_tcp.recv(socket, 0, 1000)
+          end
+
+          send(owner, :pending)
+
+          receive do
+            :reject -> :ok
+          end
+
+          case failure do
+            :upgrade ->
+              :gen_tcp.send(
+                socket,
+                "HTTP/1.1 403 Forbidden\r\ncontent-length: 18\r\n\r\n" <> remote_secret
+              )
+
+            :init ->
+              send_frame(socket, {:text, remote_secret})
+
+            :timeout ->
+              :ok
+          end
+
+          assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2000)
+        end)
+
+      session = start_proxy(port)
+      socket = connect(session)
+      assert_receive :pending, 1000
+      [conn] = Map.keys(:sys.get_state(session).connections)
+      monitor = Process.monitor(conn)
+
+      log =
+        capture_log(fn ->
+          send(server, :reject)
+
+          if failure == :timeout do
+            send(session, {:connect_timeout, conn})
+          end
+
+          assert {:error, :closed} = :gen_tcp.recv(socket, 0, 1000)
+          assert_receive {:DOWN, ^monitor, :process, ^conn, _reason}
+          assert_receive {:DOWN, _, :process, ^server, :normal}
+        end)
+
+      refute log =~ remote_secret
+      refute log =~ @token
+      assert {:ok, {127, 0, 0, 1}, _port} = Session.local_addr(session)
+    end
+  end
+
+  test "normal parent exit closes the session and listener" do
+    test = self()
+
+    owner =
+      start_supervised!(
+        {Task,
+         fn ->
+           client = Sprites.new(@token, base_url: "http://127.0.0.1:1")
+           {:ok, session} = Sprites.proxy_port(Sprites.sprite(client, "test"), 0, 8642)
+           send(test, {:session, session})
+
+           receive do
+             :stop -> :ok
+           end
+         end}
+      )
+
+    assert_receive {:session, session}
+    {:ok, address, port} = Session.local_addr(session)
+    monitor = Process.monitor(session)
+    send(owner, :stop)
+    assert_receive {:DOWN, ^monitor, :process, ^session, :normal}
+    assert {:error, :econnrefused} = :gen_tcp.connect(address, port, [:binary, active: false])
+  end
+
+  defp start_proxy(port) do
+    client = Sprites.new(@token, base_url: "http://127.0.0.1:#{port}")
+    mapping = %Sprites.Proxy.PortMapping{local_port: 0, remote_port: 8642}
+
+    start_supervised!(%{
+      id: Session,
+      restart: :temporary,
+      start: {Session, :start_link, [client, "test", mapping]}
+    })
+  end
+
+  defp connect(session) do
+    {:ok, {127, 0, 0, 1}, port} = Session.local_addr(session)
+    {:ok, socket} = :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false])
+    socket
+  end
+
+  defp server(operation) do
+    test = self()
+
+    pid =
+      start_supervised!(%{
+        id: :server,
+        restart: :temporary,
+        start:
+          {Task, :start_link,
+           [
+             fn ->
+               {:ok, listener} = :gen_tcp.listen(0, [:binary, active: false, ip: {127, 0, 0, 1}])
+               {:ok, {_, port}} = :inet.sockname(listener)
+               send(test, {:server_port, port})
+               {:ok, socket} = :gen_tcp.accept(listener)
+               operation.(socket, test)
+             end
+           ]}
+      })
+
+    Process.monitor(pid)
+    assert_receive {:server_port, port}
+    {port, pid}
+  end
+
+  defp upgrade(socket) do
+    {:ok, request} = :gen_tcp.recv(socket, 0, 1_000)
+    [_, key] = Regex.run(~r/sec-websocket-key: ([^\r]+)/i, request)
+    accept = :crypto.hash(:sha, key <> "258EAFA5-E914-47DA-95CA-C5AB0DC85B11") |> Base.encode64()
+
+    :ok =
+      :gen_tcp.send(
+        socket,
+        "HTTP/1.1 101 Switching Protocols\r\nupgrade: websocket\r\nconnection: Upgrade\r\nsec-websocket-accept: #{accept}\r\n\r\n"
+      )
+
+    {request, socket}
+  end
+
+  defp send_frame(socket, frame), do: :gen_tcp.send(socket, :cow_ws.frame(frame, %{}))
+
+  defp frame(socket, buffer \\ <<>>) do
+    case :cow_ws.parse_header(buffer, %{}, :undefined) do
+      :more ->
+        {:ok, byte} = :gen_tcp.recv(socket, 1, 1_000)
+        frame(socket, buffer <> byte)
+
+      {type, frag, rsv, len, mask, rest} ->
+        {:ok, payload} = :gen_tcp.recv(socket, len - byte_size(rest), 1_000)
+
+        {:ok, decoded, _utf8, <<>>} =
+          :cow_ws.parse_payload(rest <> payload, mask, 0, 0, type, len, frag, %{}, rsv)
+
+        {type, decoded}
+    end
+  end
+end


### PR DESCRIPTION
## Problem

A proxy listener captures the acceptor process as its server, so accepted connections do not reach the Session. The old per-connection processes also lack socket ownership and complete lifecycle cleanup. HTTP requests can stall, and stopping the Session does not reliably close its active connections.

## Change

Let the Session own accepted TCP sockets and Gun connections. Route acceptor messages to the Session, use finite WebSocket flow and TCP active-once reads, and close all connection resources on stop or owner exit. Retain certificate and hostname verification. Redact the client credential from inspection and crash status.

The public proxy_port, local_addr, and stop APIs stay the same.

## Validation

All 83 SDK tests pass with warnings treated as errors, including nine new proxy regressions. Compile and format checks pass. The regressions cover HTTP relay, handshake failures and timeouts, flow control, explicit stop, owner exit, and credential-safe diagnostics. A live private Sprite test returned HTTP 200 with the expected inner bearer; the outer Sprites credential was absent from service headers. The listener closed after Session.stop.
